### PR TITLE
refactor: add current timestamp when syncing.

### DIFF
--- a/internal/database/sync.go
+++ b/internal/database/sync.go
@@ -25,6 +25,14 @@ type SyncRepo struct {
 }
 
 func (r SyncRepo) Store(ctx context.Context, sync *domain.Sync) (*domain.Sync, error) {
+	// Check if LastSynced is nil and set it to current time if it is
+	if sync.LastSynced == nil {
+		now := time.Now()
+		sync.LastSynced = &now
+	}
+
+	sync.Status = domain.SyncStatusSuccess
+
 	queryBuilder := r.db.squirrel.
 		Insert("manga_sync").
 		Columns(
@@ -74,6 +82,14 @@ func (r SyncRepo) Delete(ctx context.Context, id int) error {
 }
 
 func (r SyncRepo) Update(ctx context.Context, sync *domain.Sync) (*domain.Sync, error) {
+	// Check if LastSynced is nil and set it to current time if it is
+	if sync.LastSynced == nil {
+		now := time.Now()
+		sync.LastSynced = &now
+	}
+
+	sync.Status = domain.SyncStatusSuccess
+
 	queryBuilder := r.db.squirrel.
 		Update("manga_sync").
 		Set("last_sync", sync.LastSynced).


### PR DESCRIPTION
This way we don't have to relay on the tachiyomi app to send us the last_sync time and status etc.