### PR TITLE
feat: use etag to update data

### DIFF
--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -88,6 +88,20 @@ CONSTRAINT sync_lock_pkey PRIMARY KEY (id)
 ALTER TABLE manga_data ADD FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE  ON UPDATE CASCADE;
 ALTER TABLE manga_sync ADD FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE  ON UPDATE CASCADE;
 ALTER TABLE sync_lock ADD FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE  ON UPDATE CASCADE;
+
+CREATE TABLE sync_data
+(
+	id INTEGER PRIMARY KEY,
+	user_api_key TEXT UNIQUE,
+
+	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+	data BLOB NOT NULL,
+	data_etag TEXT NOT NULL,
+
+	FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+)
 `
 
 var postgresMigrations = []string{
@@ -142,5 +156,20 @@ var postgresMigrations = []string{
     ALTER TABLE sync_lock DROP CONSTRAINT IF EXISTS sync_lock_acquired_by_key;
 `,
 	`ALTER TABLE manga_sync ADD COLUMN "device_id" TEXT NOT NULL DEFAULT '';
+`,
+`
+	CREATE TABLE sync_data
+	(
+		id INTEGER PRIMARY KEY,
+		user_api_key TEXT UNIQUE,
+
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+		data BLOB NOT NULL,
+		data_etag TEXT NOT NULL,
+
+		FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+	)
 `,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -78,6 +78,20 @@ CREATE TABLE sync_lock
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 );
+
+CREATE TABLE sync_data
+(
+    id INTEGER PRIMARY KEY,
+    user_api_key TEXT UNIQUE,
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    data BLOB NOT NULL,
+    data_etag TEXT NOT NULL,
+
+	FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+)
 `
 
 var sqliteMigrations = []string{
@@ -171,4 +185,19 @@ var sqliteMigrations = []string{
 	`ALTER TABLE manga_sync
 	ADD COLUMN device_id TEXT NOT NULL DEFAULT '';
 `,
+    `
+    CREATE TABLE sync_data
+    (
+        id INTEGER PRIMARY KEY,
+        user_api_key TEXT UNIQUE,
+
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+        data BLOB NOT NULL,
+        data_etag TEXT NOT NULL,
+
+        FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+    )
+    `,
 }

--- a/internal/database/sync.go
+++ b/internal/database/sync.go
@@ -493,7 +493,7 @@ func (r SyncRepo) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag st
 		return nil, errors.Wrap(err, "error executing query")
 
 	} else if rowsAffected == 0 {
-		r.log.Debug().Msgf("Sync data replace fail due to etag not match: api_key=\"%v\", etag=\"%v\"", apiKey, etag)
+		r.log.Debug().Msgf("ETag mismatch for api_key=\"%v\". Concurrent modification detected, aborting sync to prevent data overwrite. ETag=\"%v\"", apiKey, etag)
 		return nil, nil
 
 	} else {

--- a/internal/database/sync.go
+++ b/internal/database/sync.go
@@ -457,12 +457,14 @@ func (r SyncRepo) SetSyncData(ctx context.Context, apiKey string, data []byte) (
 
 		if rowsAffected, err := insertResult.RowsAffected(); err != nil {
 			return nil, errors.Wrap(err, "error executing query")
+
 		} else if rowsAffected == 0 {
 			// multi devices race condition
 			return nil, errors.New("no rows affected")
 		}
 	}
 
+	r.log.Debug().Msgf("Sync data upsert: api_key=\"%v\"", apiKey)
 	return &newEtag, nil
 }
 
@@ -489,9 +491,13 @@ func (r SyncRepo) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag st
 
 	if rowsAffected, err := result.RowsAffected(); err != nil {
 		return nil, errors.Wrap(err, "error executing query")
+
 	} else if rowsAffected == 0 {
+		r.log.Debug().Msgf("Sync data replace fail due to etag not match: api_key=\"%v\", etag=\"%v\"", apiKey, etag)
 		return nil, nil
+
 	} else {
+		r.log.Debug().Msgf("Sync data replaced: api_key=\"%v\", etag=\"%v\"", apiKey, etag)
 		return &newEtag, nil
 	}
 }

--- a/internal/database/sync.go
+++ b/internal/database/sync.go
@@ -3,13 +3,15 @@ package database
 import (
 	"context"
 	"database/sql"
+	"time"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/SyncYomi/SyncYomi/internal/domain"
 	"github.com/SyncYomi/SyncYomi/internal/logger"
 	"github.com/SyncYomi/SyncYomi/pkg/errors"
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/rs/zerolog"
-	"time"
 )
 
 func NewSyncRepo(log logger.Logger, db *DB) domain.SyncRepo {
@@ -367,4 +369,129 @@ func (r SyncRepo) DeleteSyncLockFile(ctx context.Context, apiKey string) bool {
 	r.db.log.Debug().Msgf("Sync lock file deleted: %v", apiKey)
 
 	return true
+}
+
+// Get etag of sync data.
+// For avoid memory usage, only the etag will be returned.
+func (r SyncRepo) GetSyncDataETag(ctx context.Context, apiKey string) (*string, error) {
+	var etag string
+
+	err := r.db.squirrel.
+		Select("data_etag").
+		From("sync_data").
+		Where(sq.Eq{"user_api_key": apiKey}).
+		Limit(1).
+		RunWith(r.db.handler).
+		Scan(&etag)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "error executing query")
+	}
+
+	return &etag, nil
+}
+
+// Get sync data and etag
+func (r SyncRepo) GetSyncDataAndETag(ctx context.Context, apiKey string) ([]byte, *string, error) {
+	var etag string
+	var data []byte
+
+	err := r.db.squirrel.
+		Select("data", "data_etag").
+		From("sync_data").
+		Where(sq.Eq{"user_api_key": apiKey}).
+		Limit(1).
+		RunWith(r.db.handler).
+		Scan(&data, &etag)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil, nil
+		}
+		return nil, nil, errors.Wrap(err, "error executing query")
+	}
+
+	return data, &etag, nil
+}
+
+// Create or replace sync data, returns the new etag.
+func (r SyncRepo) SetSyncData(ctx context.Context, apiKey string, data []byte) (*string, error) {
+	now := time.Now()
+	// the better way is use hash like sha1
+	// but uuid is faster than sha1
+	newEtag := "uuid=" + uuid.NewString()
+
+	updateResult, err := r.db.squirrel.
+		Update("sync_data").
+		Set("updated_at", now).
+		Set("data", data).
+		Set("data_etag", newEtag).
+		Where(sq.Eq{"user_api_key": apiKey}).
+		RunWith(r.db.handler).ExecContext(ctx)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error executing query")
+	}
+
+	if rowsAffected, err := updateResult.RowsAffected(); err != nil {
+		return nil, errors.Wrap(err, "error executing query")
+	} else if rowsAffected == 0 {
+		// new item
+		insertResult, err := r.db.squirrel.
+			Insert("sync_data").
+			Columns(
+				"user_api_key",
+				"updated_at",
+				"data",
+				"data_etag",
+			).
+			Values(apiKey, now, data, newEtag).
+			RunWith(r.db.handler).ExecContext(ctx)
+
+		if err != nil {
+			return nil, errors.Wrap(err, "error executing query")
+		}
+
+		if rowsAffected, err := insertResult.RowsAffected(); err != nil {
+			return nil, errors.Wrap(err, "error executing query")
+		} else if rowsAffected == 0 {
+			// multi devices race condition
+			return nil, errors.New("no rows affected")
+		}
+	}
+
+	return &newEtag, nil
+}
+
+// Replace sync data only if the etag matches,
+// returns the new etag if updated, or nil if not.
+func (r SyncRepo) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag string, data []byte) (*string, error) {
+	now := time.Now()
+	// the better way is use hash like sha1
+	// but uuid is faster than sha1
+	newEtag := "uuid=" + uuid.NewString()
+
+	result, err := r.db.squirrel.
+		Update("sync_data").
+		Set("updated_at", now).
+		Set("data", data).
+		Set("data_etag", newEtag).
+		Where(sq.Eq{"user_api_key": apiKey}).
+		Where(sq.Eq{"data_etag": etag}).
+		RunWith(r.db.handler).ExecContext(ctx)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error executing query")
+	}
+
+	if rowsAffected, err := result.RowsAffected(); err != nil {
+		return nil, errors.Wrap(err, "error executing query")
+	} else if rowsAffected == 0 {
+		return nil, nil
+	} else {
+		return &newEtag, nil
+	}
 }

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -15,6 +15,17 @@ type SyncRepo interface {
 	GetSyncLockFile(ctx context.Context, apiKey string) (*SyncLockFile, error)
 	UpdateSyncLockFile(ctx context.Context, syncLockFile *SyncLockFile) (*SyncLockFile, error)
 	DeleteSyncLockFile(ctx context.Context, apiKey string) bool
+
+	// Get etag of sync data.
+	// For avoid memory usage, only the etag will be returned.
+	GetSyncDataETag(ctx context.Context, apiKey string) (*string, error)
+	// Get sync data and etag
+	GetSyncDataAndETag(ctx context.Context, apiKey string) ([]byte, *string, error)
+	// Create or replace sync data, returns the new etag.
+	SetSyncData(ctx context.Context, apiKey string, data []byte) (*string, error)
+	// Replace sync data only if the etag matches,
+	// returns the new etag if updated, or nil if not.
+	SetSyncDataIfMatch(ctx context.Context, apiKey string, etag string, data []byte) (*string, error)
 }
 
 type Sync struct {

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -25,6 +25,17 @@ type Service interface {
 	CreateSyncLockFile(ctx context.Context, apiKey string, acquiredBy string) (*domain.SyncLockFile, error)
 	UpdateSyncLockFile(ctx context.Context, syncLockFile *domain.SyncLockFile) (*domain.SyncLockFile, error)
 	DeleteSyncLockFile(ctx context.Context, apiKey string) bool
+
+	// Get etag of sync data.
+	// For avoid memory usage, only the etag will be returned.
+	GetSyncDataETag(ctx context.Context, apiKey string) (*string, error)
+	// Get sync data and etag
+	GetSyncDataAndETag(ctx context.Context, apiKey string) ([]byte, *string, error)
+	// Create or replace sync data, returns the new etag.
+	SetSyncData(ctx context.Context, apiKey string, data []byte) (*string, error)
+	// Replace sync data only if the etag matches,
+	// returns the new etag if updated, or nil if not.
+	SetSyncDataIfMatch(ctx context.Context, apiKey string, etag string, data []byte) (*string, error)
 }
 
 func NewService(log logger.Logger, repo domain.SyncRepo, mdata mdata.Service, notificationSvc notification.Service, apiRepo domain.APIRepo) Service {
@@ -305,4 +316,26 @@ func (s service) updateSyncLockFile(ctx context.Context, status domain.SyncStatu
 
 	_, err := s.UpdateSyncLockFile(ctx, syncLockFile)
 	return err
+}
+
+// Get etag of sync data.
+// For avoid memory usage, only the etag will be returned.
+func (s service) GetSyncDataETag(ctx context.Context, apiKey string) (*string, error) {
+	return s.repo.GetSyncDataETag(ctx, apiKey)
+}
+
+// Get sync data and etag
+func (s service) GetSyncDataAndETag(ctx context.Context, apiKey string) ([]byte, *string, error) {
+	return s.repo.GetSyncDataAndETag(ctx, apiKey)
+}
+
+// Create or replace sync data, returns the new etag.
+func (s service) SetSyncData(ctx context.Context, apiKey string, data []byte) (*string, error) {
+	return s.repo.SetSyncData(ctx, apiKey, data)
+}
+
+// Replace sync data only if the etag matches,
+// returns the new etag if updated, or nil if not.
+func (s service) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag string, data []byte) (*string, error) {
+	return s.repo.SetSyncDataIfMatch(ctx, apiKey, etag, data)
 }


### PR DESCRIPTION
- The new endpoint is `/api/sync/content`, which supports `GET` and `PUT` methods;
- Lock is no need, use the database to guarantee inter-device conflict;
- DeviceId is no need;
- Backup data was not validated, which allows to implements E2EE or use `protobuf` format backup file;
- Backup data won't parse as json, which is helpful for memory and CPU;
- The old API can be removed in the future, including:
  - `/download`
  - `/upload`
  - `/lock` (I don't know how this works)
- I don't know why there are two tables (`manga_data` and `manga_sync`);
- In most cases, this can reduce traffic by half;

This is the client-side logic:

![mermaid-diagram-2024-04-09-042002](https://github.com/SyncYomi/SyncYomi/assets/10906962/38d350f3-262a-46b4-9cfd-336db58c2f4c)
