### PR TITLE
feat: support configuring pg ssl mode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -54,6 +54,12 @@ port = 8282
 #
 #PostgresPass = "SyncYomi"
 
+# Postgres SSL Mode
+# Set which SSL mode to communicate with Postgres. 
+# Options: disable, allow, prefer, require, verify-ca, verify-full
+# View impact of each option in official Postgres documentation: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
+#PostgresSslMode = "disable"
+
 # Base url
 # Set custom baseUrl eg /tachiyomi/ to serve in subdirectory.
 # Not needed for subdomain, or by accessing with the :port directly.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,12 @@ port = 8282
 #
 #PostgresPass = "SyncYomi"
 
+# Postgres SSL Mode
+# Set which SSL mode to communicate with Postgres. 
+# Options: disable, allow, prefer, require, verify-ca, verify-full
+# View impact of each option in official Postgres documentation: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
+#PostgresSslMode = "disable"
+
 # Base url
 # Set custom baseUrl eg /SyncYomi/ to serve in subdirectory.
 # Not needed for subdomain, or by accessing with the :port directly.
@@ -244,6 +250,7 @@ func (c *AppConfig) defaults() {
 		PostgresDatabase: "postgres",
 		PostgresUser:     "SyncYomi",
 		PostgresPass:     "SyncYomi",
+		PostgresSslMode:  "disable",
 	}
 }
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -44,7 +44,7 @@ func NewDB(cfg *domain.Config, log logger.Logger) (*DB, error) {
 		if cfg.PostgresHost == "" || cfg.PostgresPort == 0 || cfg.PostgresDatabase == "" {
 			return nil, errors.New("postgres: bad variables")
 		}
-		db.DSN = fmt.Sprintf("postgres://%v:%v@%v:%d/%v?sslmode=disable", cfg.PostgresUser, cfg.PostgresPass, cfg.PostgresHost, cfg.PostgresPort, cfg.PostgresDatabase)
+		db.DSN = fmt.Sprintf("postgres://%v:%v@%v:%d/%v?sslmode=%v", cfg.PostgresUser, cfg.PostgresPass, cfg.PostgresHost, cfg.PostgresPort, cfg.PostgresDatabase, cfg.PostgresSslMode)
 		db.Driver = "postgres"
 		databaseDriver = "postgres"
 	default:

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	PostgresDatabase string `toml:"postgresDatabase"`
 	PostgresUser     string `toml:"postgresUser"`
 	PostgresPass     string `toml:"postgresPass"`
+	PostgresSslMode  string `toml:"postgresSslMode"`
 }
 
 type ConfigUpdate struct {


### PR DESCRIPTION
Exposes postgres SSL mode configuration to config file so that users can decide if they want an encrypted connection or not.

#48