### PR TITLE
fix: Use 0.0.0.0 over localhost

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
 #
 # Default: "localhost"
 #
-host = "127.0.0.1"
+host = "0.0.0.0"
 
 # Port
 #


### PR DESCRIPTION
Use this as default, since it will be available on local network

(following Suwayomi-Server default address)