### PR TITLE
fix: unknown db type segfault

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/SyncYomi/SyncYomi/internal/domain"
 	"github.com/SyncYomi/SyncYomi/internal/logger"
 	"github.com/SyncYomi/SyncYomi/pkg/errors"
 	"github.com/rs/zerolog"
-	"sync"
 )
 
 var databaseDriver = "postgres"
@@ -40,7 +41,7 @@ func NewDB(cfg *domain.Config, log logger.Logger) (*DB, error) {
 		databaseDriver = "sqlite"
 		db.Driver = "sqlite"
 		db.DSN = dataSourceName(cfg.ConfigPath, "syncyomi.db")
-	case "postgres":
+	case "postgres", "postgresql":
 		if cfg.PostgresHost == "" || cfg.PostgresPort == 0 || cfg.PostgresDatabase == "" {
 			return nil, errors.New("postgres: bad variables")
 		}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/SyncYomi/SyncYomi/internal/api"
 	"github.com/SyncYomi/SyncYomi/internal/auth"
 	"github.com/SyncYomi/SyncYomi/internal/config"
@@ -17,9 +21,6 @@ import (
 	"github.com/asaskevich/EventBus"
 	"github.com/r3labs/sse/v2"
 	"github.com/spf13/pflag"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
 var (
@@ -54,7 +55,11 @@ func main() {
 	bus := EventBus.New()
 
 	// open database connection
-	db, _ := database.NewDB(cfg.Config, log)
+	db, err := database.NewDB(cfg.Config, log)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not create new db")
+	}
+
 	if err := db.Open(); err != nil {
 		log.Fatal().Err(err).Msg("could not open db connection")
 	}


### PR DESCRIPTION
Currently if an unknown or misspelled database type is passed to the config file the program will segfault because the error on database.NewDB is ignored.
Also added postgresql as a valid spelling for postgres.