### PR TITLE
chore(docker): update base images and improve package installation in ci.Dockerfile

### DIFF
--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM golang:1.20-alpine3.16 AS app-builder
+FROM golang:1.25-alpine3.23 AS app-builder
 
 ARG VERSION=dev
 ARG REVISION=dev
@@ -19,15 +19,15 @@ COPY . ./
 RUN go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o bin/syncyomi main.go
 
 # build final image
-FROM alpine:latest
+FROM alpine:3.23
 
-LABEL org.opencontainers.image.source = "https://github/SyncYomi/SyncYomi"
+LABEL org.opencontainers.image.source="https://github/SyncYomi/SyncYomi"
 
 ENV HOME="/config" \
 XDG_CONFIG_HOME="/config" \
 XDG_DATA_HOME="/config"
 
-RUN apk add --no-cache ca-certificates curl tzdata jq
+RUN apk add --no-cache ca-certificates curl tzdata jq && apk upgrade --no-cache
 
 WORKDIR /app
 

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func main() {
 	}()
 
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGKILL, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 
 	srv := server.NewServer(log, cfg.Config, schedulingService, updateService)
 	if err := srv.Start(); err != nil {


### PR DESCRIPTION
- Updated Go base image to version 1.25-alpine3.23. ( The previous version had  3 Critical Security and 11 High )
- Changed final image base to alpine:3.23.
- Enhanced package installation command to include apk upgrade for better security and stability.