### PR TITLE
chore(web): migrate to pnpm 11

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.10.0"
+          node-version: "22"
 
       - name: Set up corepack
         run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.10.0"
+          node-version: "22"
 
       - name: Set up corepack
         run:

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "web",
   "version": "0.0.0",
+  "packageManager": "pnpm@11.5.2",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  vue-demi: true


### PR DESCRIPTION
[pnpm 9 is EOL-ed](https://endoflife.date/pnpm) and pnpm version is never pinned in this project. This pr pins `pnpm@11.5.2`.

Related: https://github.com/NixOS/nixpkgs/pull/529525