### PR TITLE
fix: anchor release-please at 1.1.8 point via bootstrap-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-component-in-tag": false,
+  "bootstrap-sha": "4346d1f414e9a7c54d7a0af5b6ef694c2287bce8",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
release-please ran its first pass on develop and walked the entire git history (v1.1.8 tag isn't an ancestor of develop), proposing 1.2.0 off ancient feat commits. Set bootstrap-sha to the develop/v1.1.8 divergence point (4346d1f) so only the real post-1.1.8 commits count — next release becomes 1.1.9.