### PR TITLE
fix: use last-release-sha so release-please anchors at 1.1.8

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-component-in-tag": false,
-  "bootstrap-sha": "4346d1f414e9a7c54d7a0af5b6ef694c2287bce8",
+  "last-release-sha": "4346d1f414e9a7c54d7a0af5b6ef694c2287bce8",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
bootstrap-sha was ignored because the manifest already has a version. Switch to last-release-sha (develop's 1.1.8 point, 4346d1f) so release-please stops walking full history and proposes 1.1.9.