### PR TITLE
docs: updated installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,9 @@ Important Note: Treat each API key as a unique user. To ensure a seamless syncin
 
 #### Preparing for Installation
 
-Before proceeding, backup your existing Tachiyomi environment. Then go to TachiyomiSY [TachiyomiSY Preview version](https://github.com/jobobby04/TachiyomiSYPreview/releases)
-Download and Install it. Currently, it's in preview version of TachiyomiSY, but eventually it will be in the stable version.
+Before proceeding, backup your existing Tachiyomi environment by making a manual backup in `More > Data and storage` then `Create backup`. Then either download [TachiyomiSY](https://github.com/jobobby04/TachiyomiSY/releases/latest) or [Komikku](https://github.com/komikku-app/komikku/releases/latest) and install it.
 
-Then, go to `Settings > Data and Storage` in the app. Under the Sync section, input your Host details (e.g., `http://192.168.1.202:8282` or `https://sync.mydomain.tld`) and the previously generated API Key.
+Once installed, go to `More > Data and Storage` in the app and change the Sync option from `Off` to `SyncYomi`. Under the Sync section, input your Host details (e.g., `http://192.168.1.202:8282` or `https://sync.mydomain.tld`) and the previously generated API Key by either pasting it or scanning the QR code.
 
 #### Important Configuration for Direct IP Users
 


### PR DESCRIPTION
Since the `SyncYomi` synchronization option is already available in the stable builds for both TachiyomiSY and Komikku (which is a fork of TachiSY), the phrase related to "available in the TachiyomiSY preview version" was removed to reflect those changes.

Additional improvements:
- added instructions for the manual backup
- added instructions on how to enable the sync service
- changed from `Settings > Data and storage` to `More > Data and storage` to save some taps. Proof:

<img width="720" height="1462" alt="IMG_20260714_083605" src="https://github.com/user-attachments/assets/96b5f56e-07e2-4e98-bd88-32433c5cb4da" />
