### PR TITLE
chore: drop master from release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: build
 on:
   push:
     branches:
-      - "master"
       - "develop"
     tags:
       - "v*"


### PR DESCRIPTION
The master branch is being retired, so remove it from the build workflow push triggers.