### PR TITLE
fix(docker): build web with devDependencies and pinned toolchain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@
 .github
 bin
 web/node_modules
-web/dist
+
+# NOT web/dist: CI downloads the web-dist artifact into it and ci.Dockerfile
+# picks it up via COPY . ./ for the go:embed in web/build.go. Excluding it
+# breaks the release build. The local Dockerfile overwrites it from its own
+# web-builder stage, so shipping it in the context is harmless.
 web/playwright-report
 web/test-results

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+bin
+web/node_modules
+web/dist
+web/playwright-report
+web/test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,27 @@
-# build web (Node 18.12+ required by pnpm)
-FROM node:26-alpine AS web-builder
+# build web
+FROM --platform=$BUILDPLATFORM node:24-alpine AS web-builder
+
 WORKDIR /web
-COPY web/package.json web/pnpm-lock.yaml ./
-# install pnpm
-RUN npm install -g pnpm
-RUN pnpm install --frozen-lockfile --prod
-COPY web/ .
+
+COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
+
+RUN corepack enable && corepack prepare --activate
+
+RUN pnpm install --frozen-lockfile
+
+COPY web/ ./
+
 RUN pnpm run build
 
 # build app
-FROM golang:1.26-alpine3.23 AS app-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS app-builder
 
 ARG VERSION=dev
 ARG REVISION=dev
 ARG BUILDTIME
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN apk add --no-cache git make build-base tzdata
 
@@ -26,21 +34,23 @@ RUN go mod download
 
 COPY . ./
 
+# after COPY . ./ so the real dist replaces the .gitkeep placeholder web/dist holds in git
 COPY --from=web-builder /web/dist ./web/dist
-COPY --from=web-builder /web/build.go ./web
 
-RUN go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o bin/syncyomi main.go
+# Cross-compile natively on the build host (CGO disabled) instead of under QEMU.
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} \
+    go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o bin/syncyomi main.go
 
 # build final image
-FROM alpine:latest
+FROM alpine:3.24
 
 LABEL org.opencontainers.image.source="https://github.com/SyncYomi/SyncYomi"
 
 ENV HOME="/config" \
-XDG_CONFIG_HOME="/config" \
-XDG_DATA_HOME="/config"
+    XDG_CONFIG_HOME="/config" \
+    XDG_DATA_HOME="/config"
 
-RUN apk add --no-cache ca-certificates curl tzdata jq
+RUN apk add --no-cache ca-certificates curl tzdata jq && apk upgrade --no-cache
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build/web:
 	cd web && pnpm build
 
 build/docker:
-	docker build -t syncyomi:dev -f Dockerfile . --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE)
+	docker build -t syncyomi:dev -f Dockerfile . --build-arg VERSION=$(GIT_TAG) --build-arg REVISION=$(GIT_COMMIT) --build-arg BUILDTIME=$(BUILD_DATE)
 
 clean:
 	$(RM) -rf bin


### PR DESCRIPTION
Repairs the root Dockerfile so it builds again, fixes the build-arg names in the Makefile docker target, and adds a .dockerignore.