### PR TITLE
feat(sync): keep sync history and track devices per api key

### DIFF
--- a/OpenAPI.yaml
+++ b/OpenAPI.yaml
@@ -125,61 +125,6 @@ paths:
           description: No Content
         default:
           description: Unexpected error
-  /device:
-    get:
-      summary: Get all devices
-      description: Gets all devices
-      operationId: listDevices
-      tags:
-      - Devices
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Device'
-        default:
-          description: Unexpected error
-    post:
-      tags:
-        - Devices
-      summary: Store a new device
-      description: Store a new device
-      operationId: storeDevice
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Device'
-      responses:
-        '201':
-          description: Device created successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Device'
-        '500':
-          description: Internal server error
-  /device/{id}:
-    delete:
-      summary: Delete an Device
-      description: Delete an Device
-      operationId: deleteDevice
-      tags:
-        - Devices
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Device deleted successfully
-        '500':
-          description: Internal server error
   /healthz/liveness:
     get:
       summary: Get server liveness status
@@ -420,50 +365,94 @@ paths:
           description: No Content
         default:
           description: Unexpected error
-  /sync:
-    post:
-      tags:
-        - Sync
-      summary: Store sync data
-      description: Store sync data
-      operationId: storeSync
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Sync'
-      responses:
-        '201':
-          description: Sync data stored successfully
-        '400':
-          description: Bad request
-        '500':
-          description: Internal server error
+  /sync/content:
     get:
       tags:
         - Sync
-      summary: List syncs
-      description: List syncs
-      operationId: listSyncs
+      summary: Download sync data
+      description: |
+        Returns the raw sync payload stored for the API key. The payload is opaque to the
+        server (clients send a Tachiyomi backup encoded as protobuf).
+
+        Send the `ETag` from a previous response as `If-None-Match` to get `304` when
+        nothing changed. The ETag value is opaque and must be echoed back verbatim.
+      operationId: getSyncContent
+      security:
+        - ApiKeyAuth: []
       parameters:
-        - in: query
-          name: apiKey
-          schema:
-            type: string
-          required: true
-          description: User's API key
+        - $ref: '#/components/parameters/IfNoneMatch'
+        - $ref: '#/components/parameters/DeviceId'
+        - $ref: '#/components/parameters/DeviceName'
       responses:
         '200':
-          description: A list of syncs
-          content:
-            application/json:
+          description: Sync payload
+          headers:
+            ETag:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Sync'
+                type: string
+              description: Opaque version tag of the payload
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '304':
+          description: Not modified since the `If-None-Match` ETag
+        '401':
+          description: Unauthorized
+        '404':
+          description: No sync data stored for this API key
+        '500':
+          description: Internal server error
+    put:
+      tags:
+        - Sync
+      summary: Upload sync data
+      description: |
+        Replaces the sync payload stored for the API key and returns the new `ETag`.
+
+        Send the last known `ETag` as `If-Match` to get `412` instead of overwriting data
+        another device uploaded in the meantime; the client should then download, merge and
+        upload again. Without `If-Match` the payload is replaced unconditionally.
+
+        The body may be gzip-compressed (`Content-Encoding: gzip`). Bodies larger than the
+        configured `syncMaxBodySizeMB` are rejected with `413`.
+      operationId: putSyncContent
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/DeviceId'
+        - $ref: '#/components/parameters/DeviceName'
+        - name: Content-Encoding
+          in: header
+          required: false
+          schema:
+            type: string
+            enum: [gzip]
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: Stored
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: New opaque version tag of the payload
         '400':
-          description: Bad request
+          description: Unreadable body
+        '401':
+          description: Unauthorized
+        '412':
+          description: The `If-Match` ETag does not match the stored payload
+        '413':
+          description: Body larger than the configured limit
         '500':
           description: Internal server error
   /sync/event:
@@ -473,11 +462,15 @@ paths:
       summary: Report sync event
       description: |
         Report a device-reported sync status (e.g. started, success, failed, cancelled).
-        Used by the Android app to notify the server of sync progress. Triggers configured
-        notifications (Discord, Telegram, etc.) with optional device name.
+        Used by clients to notify the server of sync progress. Triggers configured
+        notifications (Discord, Telegram, etc.) and updates the device and status shown
+        in the web UI.
       operationId: reportSyncEvent
       security:
         - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+        - $ref: '#/components/parameters/DeviceName'
       requestBody:
         required: true
         content:
@@ -493,80 +486,110 @@ paths:
           description: Unauthorized (missing or invalid API key)
         '500':
           description: Internal server error
-  /sync/{apiKey}:
+  /sync/admin/{apikey}/status:
     get:
       tags:
-        - Sync
-      summary: Get sync by API key
-      description: Get sync by API key
-      operationId: getSyncByApiKey
+        - Sync Admin
+      summary: Sync status of an API key
+      operationId: getSyncStatus
+      security:
+        - CookieAuth: []
       parameters:
-        - in: path
-          name: apiKey
-          schema:
-            type: string
-          required: true
-          description: User's API key
+        - $ref: '#/components/parameters/ApiKeyPath'
       responses:
         '200':
-          description: Sync data
+          description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Sync'
-        '400':
-          description: Bad request
+                $ref: '#/components/schemas/SyncStatus'
+        '401':
+          description: Unauthorized
         '404':
-          description: Sync not found
+          description: Nothing known about this API key yet
         '500':
           description: Internal server error
-    delete:
-      tags:
-        - Sync
-      summary: Delete sync data
-      description: Delete sync data
-      operationId: deleteSync
-      parameters:
-        - in: path
-          name: apiKey
-          schema:
-            type: integer
-          required: true
-          description: Sync ID
-      responses:
-        '204':
-          description: Sync data deleted successfully
-        '400':
-          description: Bad request
-        '404':
-          description: Sync not found
-        '500':
-          description: Internal server error
-  /sync/device/{id}:
+  /sync/admin/{apikey}/devices:
     get:
       tags:
-        - Sync
-      summary: Get sync by device ID
-      description: Get sync by device ID
-      operationId: getSyncByDeviceID
+        - Sync Admin
+      summary: Devices that synced with an API key
+      operationId: listSyncDevices
+      security:
+        - CookieAuth: []
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
-          description: Device ID
+        - $ref: '#/components/parameters/ApiKeyPath'
       responses:
         '200':
-          description: Sync data
+          description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Sync'
+                type: array
+                items:
+                  $ref: '#/components/schemas/SyncDevice'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+  /sync/admin/{apikey}/history:
+    get:
+      tags:
+        - Sync Admin
+      summary: Previous sync payloads kept for an API key
+      description: Newest first. The number of entries kept is `syncHistoryLimit`.
+      operationId: listSyncHistory
+      security:
+        - CookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ApiKeyPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SyncHistoryEntry'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+  /sync/admin/{apikey}/history/{id}/restore:
+    post:
+      tags:
+        - Sync Admin
+      summary: Roll back to a previous sync payload
+      description: |
+        Makes the history entry the current payload under a new ETag. Devices holding the
+        old ETag get `412` on their next `If-Match` upload and re-sync.
+      operationId: restoreSyncHistory
+      security:
+        - CookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ApiKeyPath'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Restored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  etag:
+                    type: string
         '400':
-          description: Bad request
+          description: Invalid id
+        '401':
+          description: Unauthorized
         '404':
-          description: Sync not found
+          description: Unknown history entry
         '500':
           description: Internal server error
   /updates/latest:
@@ -610,12 +633,56 @@ tags:
     description: Notification endpoints
   - name: Updates
     description: Update endpoints
-  - name: Devices
-    description: Device endpoints
   - name: Sync
-    description: Sync endpoints
+    description: Sync endpoints used by clients (API key)
+  - name: Sync Admin
+    description: Sync inspection endpoints used by the web UI (session)
 
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Token
+    CookieAuth:
+      type: apiKey
+      in: cookie
+      name: user_session
+  parameters:
+    ApiKeyPath:
+      name: apikey
+      in: path
+      required: true
+      schema:
+        type: string
+    IfNoneMatch:
+      name: If-None-Match
+      in: header
+      required: false
+      schema:
+        type: string
+      description: ETag from a previous response
+    IfMatch:
+      name: If-Match
+      in: header
+      required: false
+      schema:
+        type: string
+      description: ETag the client last saw
+    DeviceId:
+      name: X-Device-ID
+      in: header
+      required: false
+      schema:
+        type: string
+      description: Stable identifier of the client device (optional, used for the device list)
+    DeviceName:
+      name: X-Device-Name
+      in: header
+      required: false
+      schema:
+        type: string
+      description: Human readable device name (optional)
   schemas:
     APIKey:
       type: object
@@ -636,21 +703,6 @@ components:
         - key
         - scopes
         - created_at
-    Device:
-      type: object
-      properties:
-        id:
-          type: integer
-        name:
-          type: string
-        user_api_key:
-          $ref: '#/components/schemas/APIKey'
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
     User:
       type: object
       properties:
@@ -814,25 +866,67 @@ components:
         browser_download_url:
           type: string
           description: The download URL for the asset
-    Sync:
+    SyncStatus:
+      type: object
+      properties:
+        last_synced_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Last successful upload
+        last_event_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_event:
+          type: string
+        last_status:
+          type: string
+          enum: ['', running, success, error, cancelled]
+        last_device:
+          type: string
+        last_message:
+          type: string
+        data_size:
+          type: integer
+          format: int64
+          description: Size of the stored payload in bytes
+        data_updated_at:
+          type: string
+          format: date-time
+          nullable: true
+    SyncDevice:
       type: object
       properties:
         id:
           type: integer
-        last_synced:
+        device_id:
+          type: string
+        device_name:
+          type: string
+        last_seen:
           type: string
           format: date-time
-        status:
+        last_event:
           type: string
-          enum: [ pending, syncing, success, error ]
-        device:
-          $ref: '#/components/schemas/Device'
-        user_api_key:
-          $ref: '#/components/schemas/APIKey'
+        last_status:
+          type: string
+        last_message:
+          type: string
         created_at:
           type: string
           format: date-time
-        updated_at:
+    SyncHistoryEntry:
+      type: object
+      properties:
+        id:
+          type: integer
+        etag:
+          type: string
+        size:
+          type: integer
+          format: int64
+        created_at:
           type: string
           format: date-time
     SyncEventRequest:
@@ -850,6 +944,9 @@ components:
             - SYNC_ERROR
             - SYNC_CANCELLED
           description: The sync event type reported by the device
+        device_id:
+          type: string
+          description: Optional stable identifier of the device (the `X-Device-ID` header takes precedence)
         device_name:
           type: string
           description: Optional name of the device that triggered the sync

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,16 @@ checkForUpdates = true
 #
 #syncMaxBodySizeMB = 64
 
+# Sync history
+#
+# Default: 10
+#
+# Number of previous sync payloads kept per API key so a bad sync can be
+# rolled back from the web UI. Each entry stores a full payload.
+# Set to 0 to disable.
+#
+#syncHistoryLimit = 10
+
 # Session secret
 #
 sessionSecret = "{{ .sessionSecret }}"
@@ -275,6 +285,7 @@ func (c *AppConfig) defaults() {
 		PostgresSslMode:  "disable",
 
 		SyncMaxBodySizeMB: 64,
+		SyncHistoryLimit:  10,
 	}
 }
 

--- a/internal/database/api.go
+++ b/internal/database/api.go
@@ -130,7 +130,7 @@ func (r *APIRepo) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-var apiKeyDependentTables = []string{"sync_data"}
+var apiKeyDependentTables = []string{"sync_data", "sync_data_history", "sync_device", "sync_status"}
 
 func (r *APIRepo) GetKeys(ctx context.Context) ([]domain.APIKey, error) {
 	queryBuilder := r.db.squirrel.

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -56,6 +56,45 @@ CREATE TABLE sync_data
 	data_etag TEXT NOT NULL,
 
 	FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+);
+
+CREATE TABLE sync_data_history
+(
+	id           SERIAL PRIMARY KEY,
+	user_api_key TEXT NOT NULL,
+	data_etag    TEXT NOT NULL,
+	size         BIGINT NOT NULL,
+	created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	data         BYTEA NOT NULL,
+	FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+);
+CREATE INDEX idx_sync_data_history_key ON sync_data_history (user_api_key, id DESC);
+
+CREATE TABLE sync_device
+(
+	id           SERIAL PRIMARY KEY,
+	user_api_key TEXT NOT NULL,
+	device_id    TEXT NOT NULL,
+	device_name  TEXT NOT NULL DEFAULT '',
+	last_seen    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	last_event   TEXT NOT NULL DEFAULT '',
+	last_status  TEXT NOT NULL DEFAULT '',
+	last_message TEXT NOT NULL DEFAULT '',
+	created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE (user_api_key, device_id),
+	FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+);
+
+CREATE TABLE sync_status
+(
+	user_api_key   TEXT PRIMARY KEY,
+	last_synced_at TIMESTAMP,
+	last_event_at  TIMESTAMP,
+	last_event     TEXT NOT NULL DEFAULT '',
+	last_status    TEXT NOT NULL DEFAULT '',
+	last_device    TEXT NOT NULL DEFAULT '',
+	last_message   TEXT NOT NULL DEFAULT '',
+	FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 )
 `
 
@@ -144,5 +183,45 @@ END $$;
 	DROP TABLE IF EXISTS manga_data;
 	DROP TABLE IF EXISTS manga_sync;
 	DROP TABLE IF EXISTS sync_lock;
+`,
+	`
+	CREATE TABLE sync_data_history
+	(
+		id           SERIAL PRIMARY KEY,
+		user_api_key TEXT NOT NULL,
+		data_etag    TEXT NOT NULL,
+		size         BIGINT NOT NULL,
+		created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		data         BYTEA NOT NULL,
+		FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+	);
+	CREATE INDEX idx_sync_data_history_key ON sync_data_history (user_api_key, id DESC);
+
+	CREATE TABLE sync_device
+	(
+		id           SERIAL PRIMARY KEY,
+		user_api_key TEXT NOT NULL,
+		device_id    TEXT NOT NULL,
+		device_name  TEXT NOT NULL DEFAULT '',
+		last_seen    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		last_event   TEXT NOT NULL DEFAULT '',
+		last_status  TEXT NOT NULL DEFAULT '',
+		last_message TEXT NOT NULL DEFAULT '',
+		created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE (user_api_key, device_id),
+		FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+	);
+
+	CREATE TABLE sync_status
+	(
+		user_api_key   TEXT PRIMARY KEY,
+		last_synced_at TIMESTAMP,
+		last_event_at  TIMESTAMP,
+		last_event     TEXT NOT NULL DEFAULT '',
+		last_status    TEXT NOT NULL DEFAULT '',
+		last_device    TEXT NOT NULL DEFAULT '',
+		last_message   TEXT NOT NULL DEFAULT '',
+		FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+	);
 `,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -54,6 +54,45 @@ CREATE TABLE sync_data
     data_etag TEXT NOT NULL,
 
     FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+);
+
+CREATE TABLE sync_data_history
+(
+    id           INTEGER PRIMARY KEY,
+    user_api_key TEXT NOT NULL,
+    data_etag    TEXT NOT NULL,
+    size         INTEGER NOT NULL,
+    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    data         BLOB NOT NULL,
+    FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+);
+CREATE INDEX idx_sync_data_history_key ON sync_data_history (user_api_key, id DESC);
+
+CREATE TABLE sync_device
+(
+    id           INTEGER PRIMARY KEY,
+    user_api_key TEXT NOT NULL,
+    device_id    TEXT NOT NULL,
+    device_name  TEXT NOT NULL DEFAULT '',
+    last_seen    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_event   TEXT NOT NULL DEFAULT '',
+    last_status  TEXT NOT NULL DEFAULT '',
+    last_message TEXT NOT NULL DEFAULT '',
+    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_api_key, device_id),
+    FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+);
+
+CREATE TABLE sync_status
+(
+    user_api_key   TEXT PRIMARY KEY,
+    last_synced_at TIMESTAMP,
+    last_event_at  TIMESTAMP,
+    last_event     TEXT NOT NULL DEFAULT '',
+    last_status    TEXT NOT NULL DEFAULT '',
+    last_device    TEXT NOT NULL DEFAULT '',
+    last_message   TEXT NOT NULL DEFAULT '',
+    FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 )
 `
 
@@ -167,5 +206,45 @@ var sqliteMigrations = []string{
 	DROP TABLE IF EXISTS manga_data;
 	DROP TABLE IF EXISTS manga_sync;
 	DROP TABLE IF EXISTS sync_lock;
+`,
+	`
+	CREATE TABLE sync_data_history
+	(
+	    id           INTEGER PRIMARY KEY,
+	    user_api_key TEXT NOT NULL,
+	    data_etag    TEXT NOT NULL,
+	    size         INTEGER NOT NULL,
+	    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	    data         BLOB NOT NULL,
+	    FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+	);
+	CREATE INDEX idx_sync_data_history_key ON sync_data_history (user_api_key, id DESC);
+
+	CREATE TABLE sync_device
+	(
+	    id           INTEGER PRIMARY KEY,
+	    user_api_key TEXT NOT NULL,
+	    device_id    TEXT NOT NULL,
+	    device_name  TEXT NOT NULL DEFAULT '',
+	    last_seen    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	    last_event   TEXT NOT NULL DEFAULT '',
+	    last_status  TEXT NOT NULL DEFAULT '',
+	    last_message TEXT NOT NULL DEFAULT '',
+	    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	    UNIQUE (user_api_key, device_id),
+	    FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+	);
+
+	CREATE TABLE sync_status
+	(
+	    user_api_key   TEXT PRIMARY KEY,
+	    last_synced_at TIMESTAMP,
+	    last_event_at  TIMESTAMP,
+	    last_event     TEXT NOT NULL DEFAULT '',
+	    last_status    TEXT NOT NULL DEFAULT '',
+	    last_device    TEXT NOT NULL DEFAULT '',
+	    last_message   TEXT NOT NULL DEFAULT '',
+	    FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
+	);
 `,
 }

--- a/internal/database/sync.go
+++ b/internal/database/sync.go
@@ -14,16 +14,18 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func NewSyncRepo(log logger.Logger, db *DB) domain.SyncRepo {
+func NewSyncRepo(log logger.Logger, db *DB, historyLimit int) domain.SyncRepo {
 	return &SyncRepo{
-		log: log.With().Str("repo", "sync").Logger(),
-		db:  db,
+		log:          log.With().Str("repo", "sync").Logger(),
+		db:           db,
+		historyLimit: historyLimit,
 	}
 }
 
 type SyncRepo struct {
-	log zerolog.Logger
-	db  *DB
+	log          zerolog.Logger
+	db           *DB
+	historyLimit int
 }
 
 // Wire format ("uuid=<uuid4>", unquoted) is part of the client contract:
@@ -78,38 +80,42 @@ func (r SyncRepo) GetSyncDataAndETag(ctx context.Context, apiKey string) ([]byte
 }
 
 func (r SyncRepo) SetSyncData(ctx context.Context, apiKey string, data []byte) (*string, error) {
-	now := time.Now()
-	etag := newETag()
-
-	_, err := r.db.squirrel.
-		Insert("sync_data").
-		Columns("user_api_key", "created_at", "updated_at", "data", "data_etag").
-		Values(apiKey, now, now, data, etag).
-		Suffix("ON CONFLICT (user_api_key) DO UPDATE SET data = EXCLUDED.data, data_etag = EXCLUDED.data_etag, updated_at = EXCLUDED.updated_at").
-		RunWith(r.db.handler).
-		ExecContext(ctx)
-
+	tx, err := r.db.handler.BeginTx(ctx, nil)
 	if err != nil {
-		r.log.Err(err).Msg("error upserting sync data")
-		return nil, errors.Wrap(err, "error executing query")
+		return nil, errors.Wrap(err, "error starting transaction")
+	}
+	defer r.rollback(tx)
+
+	etag, err := r.upsertSyncData(ctx, tx, apiKey, data)
+	if err != nil {
+		return nil, err
 	}
 
-	return &etag, nil
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "error committing transaction")
+	}
+
+	return etag, nil
 }
 
 // Returns (nil, nil) when the etag does not match, including when no data exists yet.
 func (r SyncRepo) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag string, data []byte) (*string, error) {
-	now := time.Now()
 	newEtag := newETag()
+
+	tx, err := r.db.handler.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error starting transaction")
+	}
+	defer r.rollback(tx)
 
 	result, err := r.db.squirrel.
 		Update("sync_data").
-		Set("updated_at", now).
+		Set("updated_at", time.Now()).
 		Set("data", data).
 		Set("data_etag", newEtag).
 		Where(sq.Eq{"user_api_key": apiKey}).
 		Where(sq.Eq{"data_etag": etag}).
-		RunWith(r.db.handler).
+		RunWith(tx).
 		ExecContext(ctx)
 
 	if err != nil {
@@ -126,5 +132,258 @@ func (r SyncRepo) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag st
 		return nil, nil
 	}
 
+	if err := r.recordHistory(ctx, tx, apiKey, newEtag, data); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "error committing transaction")
+	}
+
 	return &newEtag, nil
+}
+
+func (r SyncRepo) upsertSyncData(ctx context.Context, tx *sql.Tx, apiKey string, data []byte) (*string, error) {
+	now := time.Now()
+	etag := newETag()
+
+	_, err := r.db.squirrel.
+		Insert("sync_data").
+		Columns("user_api_key", "created_at", "updated_at", "data", "data_etag").
+		Values(apiKey, now, now, data, etag).
+		Suffix("ON CONFLICT (user_api_key) DO UPDATE SET data = EXCLUDED.data, data_etag = EXCLUDED.data_etag, updated_at = EXCLUDED.updated_at").
+		RunWith(tx).
+		ExecContext(ctx)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error upserting sync data")
+	}
+
+	if err := r.recordHistory(ctx, tx, apiKey, etag, data); err != nil {
+		return nil, err
+	}
+
+	return &etag, nil
+}
+
+func (r SyncRepo) recordHistory(ctx context.Context, tx *sql.Tx, apiKey, etag string, data []byte) error {
+	if r.historyLimit <= 0 {
+		return nil
+	}
+
+	_, err := r.db.squirrel.
+		Insert("sync_data_history").
+		Columns("user_api_key", "data_etag", "size", "created_at", "data").
+		Values(apiKey, etag, len(data), time.Now(), data).
+		RunWith(tx).
+		ExecContext(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error recording sync history")
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM sync_data_history
+		WHERE user_api_key = $1 AND id NOT IN (
+			SELECT id FROM sync_data_history WHERE user_api_key = $1 ORDER BY id DESC LIMIT $2
+		)`, apiKey, r.historyLimit)
+	if err != nil {
+		return errors.Wrap(err, "error pruning sync history")
+	}
+
+	return nil
+}
+
+func (r SyncRepo) ListHistory(ctx context.Context, apiKey string) ([]domain.SyncHistoryEntry, error) {
+	rows, err := r.db.squirrel.
+		Select("id", "data_etag", "size", "created_at").
+		From("sync_data_history").
+		Where(sq.Eq{"user_api_key": apiKey}).
+		OrderBy("id DESC").
+		RunWith(r.db.handler).
+		QueryContext(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "error executing query")
+	}
+	defer rows.Close()
+
+	entries := make([]domain.SyncHistoryEntry, 0)
+	for rows.Next() {
+		var e domain.SyncHistoryEntry
+		if err := rows.Scan(&e.ID, &e.ETag, &e.Size, &e.CreatedAt); err != nil {
+			return nil, errors.Wrap(err, "error scanning row")
+		}
+		entries = append(entries, e)
+	}
+
+	return entries, rows.Err()
+}
+
+func (r SyncRepo) RestoreHistory(ctx context.Context, apiKey string, id int) (*string, error) {
+	tx, err := r.db.handler.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error starting transaction")
+	}
+	defer r.rollback(tx)
+
+	var data []byte
+	err = r.db.squirrel.
+		Select("data").
+		From("sync_data_history").
+		Where(sq.Eq{"user_api_key": apiKey, "id": id}).
+		RunWith(tx).
+		QueryRowContext(ctx).
+		Scan(&data)
+	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, errors.Wrap(err, "error executing query")
+	}
+
+	etag, err := r.upsertSyncData(ctx, tx, apiKey, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "error committing transaction")
+	}
+
+	return etag, nil
+}
+
+func (r SyncRepo) TouchDevice(ctx context.Context, apiKey string, dev domain.DeviceInfo, event, status, message string) error {
+	deviceKey := dev.Key()
+	if deviceKey == "" {
+		return nil
+	}
+
+	now := time.Now()
+	_, err := r.db.handler.ExecContext(ctx, `
+		INSERT INTO sync_device (user_api_key, device_id, device_name, last_seen, last_event, last_status, last_message, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (user_api_key, device_id) DO UPDATE SET
+			device_name  = CASE WHEN EXCLUDED.device_name = '' THEN sync_device.device_name ELSE EXCLUDED.device_name END,
+			last_seen    = EXCLUDED.last_seen,
+			last_event   = CASE WHEN EXCLUDED.last_event = '' THEN sync_device.last_event ELSE EXCLUDED.last_event END,
+			last_status  = CASE WHEN EXCLUDED.last_status = '' THEN sync_device.last_status ELSE EXCLUDED.last_status END,
+			last_message = CASE WHEN EXCLUDED.last_event = '' THEN sync_device.last_message ELSE EXCLUDED.last_message END`,
+		apiKey, deviceKey, dev.Name, now, event, status, message, now)
+	if err != nil {
+		return errors.Wrap(err, "error upserting device")
+	}
+
+	return nil
+}
+
+func (r SyncRepo) ListDevices(ctx context.Context, apiKey string) ([]domain.SyncDevice, error) {
+	rows, err := r.db.squirrel.
+		Select("id", "device_id", "device_name", "last_seen", "last_event", "last_status", "last_message", "created_at").
+		From("sync_device").
+		Where(sq.Eq{"user_api_key": apiKey}).
+		OrderBy("last_seen DESC", "id DESC").
+		RunWith(r.db.handler).
+		QueryContext(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "error executing query")
+	}
+	defer rows.Close()
+
+	devices := make([]domain.SyncDevice, 0)
+	for rows.Next() {
+		var d domain.SyncDevice
+		if err := rows.Scan(&d.ID, &d.DeviceID, &d.DeviceName, &d.LastSeen, &d.LastEvent, &d.LastStatus, &d.LastMessage, &d.CreatedAt); err != nil {
+			return nil, errors.Wrap(err, "error scanning row")
+		}
+		devices = append(devices, d)
+	}
+
+	return devices, rows.Err()
+}
+
+func (r SyncRepo) UpsertStatus(ctx context.Context, apiKey string, st domain.SyncStatus) error {
+	_, err := r.db.handler.ExecContext(ctx, `
+		INSERT INTO sync_status (user_api_key, last_synced_at, last_event_at, last_event, last_status, last_device, last_message)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (user_api_key) DO UPDATE SET
+			last_synced_at = COALESCE(EXCLUDED.last_synced_at, sync_status.last_synced_at),
+			last_event_at  = COALESCE(EXCLUDED.last_event_at, sync_status.last_event_at),
+			last_event     = CASE WHEN EXCLUDED.last_event = '' THEN sync_status.last_event ELSE EXCLUDED.last_event END,
+			last_status    = CASE WHEN EXCLUDED.last_status = '' THEN sync_status.last_status ELSE EXCLUDED.last_status END,
+			last_device    = CASE WHEN EXCLUDED.last_device = '' THEN sync_status.last_device ELSE EXCLUDED.last_device END,
+			last_message   = CASE WHEN EXCLUDED.last_event = '' THEN sync_status.last_message ELSE EXCLUDED.last_message END`,
+		apiKey, nullTime(st.LastSyncedAt), nullTime(st.LastEventAt), st.LastEvent, st.LastStatus, st.LastDevice, st.LastMessage)
+	if err != nil {
+		return errors.Wrap(err, "error upserting sync status")
+	}
+
+	return nil
+}
+
+func (r SyncRepo) GetStatus(ctx context.Context, apiKey string) (*domain.SyncStatus, error) {
+	var (
+		st    domain.SyncStatus
+		found bool
+	)
+
+	var lastSynced, lastEvent sql.NullTime
+	err := r.db.squirrel.
+		Select("last_synced_at", "last_event_at", "last_event", "last_status", "last_device", "last_message").
+		From("sync_status").
+		Where(sq.Eq{"user_api_key": apiKey}).
+		RunWith(r.db.handler).
+		QueryRowContext(ctx).
+		Scan(&lastSynced, &lastEvent, &st.LastEvent, &st.LastStatus, &st.LastDevice, &st.LastMessage)
+	switch {
+	case err == nil:
+		found = true
+		st.LastSyncedAt = timePtr(lastSynced)
+		st.LastEventAt = timePtr(lastEvent)
+	case stderrors.Is(err, sql.ErrNoRows):
+	default:
+		return nil, errors.Wrap(err, "error executing query")
+	}
+
+	var updatedAt sql.NullTime
+	err = r.db.squirrel.
+		Select("length(data)", "updated_at").
+		From("sync_data").
+		Where(sq.Eq{"user_api_key": apiKey}).
+		RunWith(r.db.handler).
+		QueryRowContext(ctx).
+		Scan(&st.DataSize, &updatedAt)
+	switch {
+	case err == nil:
+		found = true
+		st.DataUpdatedAt = timePtr(updatedAt)
+	case stderrors.Is(err, sql.ErrNoRows):
+	default:
+		return nil, errors.Wrap(err, "error executing query")
+	}
+
+	if !found {
+		return nil, nil
+	}
+
+	return &st, nil
+}
+
+func (r SyncRepo) rollback(tx *sql.Tx) {
+	if err := tx.Rollback(); err != nil && !stderrors.Is(err, sql.ErrTxDone) {
+		r.log.Error().Err(err).Msg("error rolling back transaction")
+	}
+}
+
+func nullTime(t *time.Time) sql.NullTime {
+	if t == nil {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: *t, Valid: true}
+}
+
+func timePtr(t sql.NullTime) *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	return &t.Time
 }

--- a/internal/database/sync_test.go
+++ b/internal/database/sync_test.go
@@ -3,11 +3,15 @@ package database
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/SyncYomi/SyncYomi/internal/domain"
 	"github.com/rs/zerolog"
 )
 
@@ -60,7 +64,7 @@ func TestSQLiteSchemaVersion(t *testing.T) {
 		t.Errorf("user_version = %d, want %d", version, len(sqliteMigrations))
 	}
 
-	for _, table := range []string{"users", "api_key", "notification", "sync_data"} {
+	for _, table := range []string{"users", "api_key", "notification", "sync_data", "sync_data_history", "sync_device", "sync_status"} {
 		var name string
 		err := db.handler.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = $1`, table).Scan(&name)
 		if err != nil {
@@ -71,7 +75,7 @@ func TestSQLiteSchemaVersion(t *testing.T) {
 
 func TestSyncRepo_GetUnknownKey(t *testing.T) {
 	db := newTestDB(t)
-	repo := SyncRepo{log: zerolog.Nop(), db: db}
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
 	ctx := context.Background()
 
 	etag, err := repo.GetSyncDataETag(ctx, "missing")
@@ -88,7 +92,7 @@ func TestSyncRepo_GetUnknownKey(t *testing.T) {
 func TestSyncRepo_SetSyncDataUpserts(t *testing.T) {
 	db := newTestDB(t)
 	insertTestAPIKey(t, db, "key1")
-	repo := SyncRepo{log: zerolog.Nop(), db: db}
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
 	ctx := context.Background()
 
 	etag1, err := repo.SetSyncData(ctx, "key1", []byte("v1"))
@@ -124,7 +128,7 @@ func TestSyncRepo_SetSyncDataUpserts(t *testing.T) {
 func TestSyncRepo_SetSyncDataConcurrentFirstWrite(t *testing.T) {
 	db := newTestDB(t)
 	insertTestAPIKey(t, db, "key1")
-	repo := SyncRepo{log: zerolog.Nop(), db: db}
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
 	ctx := context.Background()
 
 	const writers = 10
@@ -159,7 +163,7 @@ func TestSyncRepo_SetSyncDataConcurrentFirstWrite(t *testing.T) {
 func TestSyncRepo_SetSyncDataIfMatch(t *testing.T) {
 	db := newTestDB(t)
 	insertTestAPIKey(t, db, "key1")
-	repo := SyncRepo{log: zerolog.Nop(), db: db}
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
 	ctx := context.Background()
 
 	// no data yet: If-Match can never match
@@ -197,7 +201,7 @@ func TestSyncRepo_SetSyncDataIfMatch(t *testing.T) {
 
 func TestSyncRepo_ReadsHonourContext(t *testing.T) {
 	db := newTestDB(t)
-	repo := SyncRepo{log: zerolog.Nop(), db: db}
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -214,7 +218,7 @@ func TestAPIRepo_DeleteCascadesSyncData(t *testing.T) {
 	db := newTestDB(t)
 	insertTestAPIKey(t, db, "key1")
 	insertTestAPIKey(t, db, "key2")
-	syncRepo := SyncRepo{log: zerolog.Nop(), db: db}
+	syncRepo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
 	apiRepo := APIRepo{log: zerolog.Nop(), db: db}
 	ctx := context.Background()
 
@@ -225,17 +229,244 @@ func TestAPIRepo_DeleteCascadesSyncData(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if err := syncRepo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d"}, "", "", ""); err != nil {
+		t.Fatal(err)
+	}
 	if err := apiRepo.Delete(ctx, "key1"); err != nil {
 		t.Fatal(err)
 	}
-
-	if n := countRows(t, db, "sync_data", "key1"); n != 0 {
-		t.Errorf("sync_data rows for deleted key = %d, want 0", n)
+	for _, table := range apiKeyDependentTables {
+		if n := countRows(t, db, table, "key1"); n != 0 {
+			t.Errorf("%s rows for deleted key = %d, want 0", table, n)
+		}
 	}
 	if n := countRows(t, db, "sync_data", "key2"); n != 1 {
 		t.Errorf("sync_data rows for other key = %d, want 1", n)
 	}
 	if _, err := apiRepo.Get(ctx, "key1"); err == nil {
 		t.Error("deleted api key still readable")
+	}
+}
+
+func TestSyncRepo_History(t *testing.T) {
+	db := newTestDB(t)
+	insertTestAPIKey(t, db, "key1")
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
+	ctx := context.Background()
+
+	var etags []string
+	for i := 1; i <= 5; i++ {
+		etag, err := repo.SetSyncData(ctx, "key1", []byte{byte(i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		etags = append(etags, *etag)
+	}
+
+	history, err := repo.ListHistory(ctx, "key1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("history len = %d, want 3", len(history))
+	}
+	for i, want := range []string{etags[4], etags[3], etags[2]} {
+		if history[i].ETag != want || history[i].Size != 1 {
+			t.Errorf("history[%d] = %+v, want etag %q size 1", i, history[i], want)
+		}
+	}
+
+	// restore the oldest kept entry (payload 3)
+	newEtag, err := repo.RestoreHistory(ctx, "key1", history[2].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, etag, err := repo.GetSyncDataAndETag(ctx, "key1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, []byte{3}) || *etag != *newEtag {
+		t.Errorf("after restore data=%v etag=%q, want [3]/%q", data, *etag, *newEtag)
+	}
+
+	history, _ = repo.ListHistory(ctx, "key1")
+	if len(history) != 3 || history[0].ETag != *newEtag {
+		t.Errorf("history after restore = %+v", history)
+	}
+
+	if _, err := repo.RestoreHistory(ctx, "key1", 99999); !stderrors.Is(err, domain.ErrNotFound) {
+		t.Errorf("restore unknown id err = %v, want ErrNotFound", err)
+	}
+
+	// IfMatch writes are recorded too
+	if _, err := repo.SetSyncDataIfMatch(ctx, "key1", *newEtag, []byte{9}); err != nil {
+		t.Fatal(err)
+	}
+	history, _ = repo.ListHistory(ctx, "key1")
+	if history[0].Size != 1 || history[0].ETag == *newEtag {
+		t.Errorf("IfMatch write not recorded: %+v", history)
+	}
+}
+
+func TestSyncRepo_HistoryDisabled(t *testing.T) {
+	db := newTestDB(t)
+	insertTestAPIKey(t, db, "key1")
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 0}
+	ctx := context.Background()
+
+	if _, err := repo.SetSyncData(ctx, "key1", []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if n := countRows(t, db, "sync_data_history", "key1"); n != 0 {
+		t.Errorf("history rows = %d, want 0", n)
+	}
+}
+
+func TestSyncRepo_Devices(t *testing.T) {
+	db := newTestDB(t)
+	insertTestAPIKey(t, db, "key1")
+	repo := SyncRepo{log: zerolog.Nop(), db: db}
+	ctx := context.Background()
+
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{}, "", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if n := countRows(t, db, "sync_device", "key1"); n != 0 {
+		t.Errorf("anonymous touch created %d rows", n)
+	}
+
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1", Name: "Phone"}, "SYNC_SUCCESS", "success", "done"); err != nil {
+		t.Fatal(err)
+	}
+	// second touch with no name/event keeps what we know
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1"}, "", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	// name-only device falls back to name as id
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{Name: "Tablet"}, "SYNC_STARTED", "running", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	devices, err := repo.ListDevices(ctx, "key1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(devices) != 2 {
+		t.Fatalf("devices = %+v, want 2", devices)
+	}
+	byID := map[string]domain.SyncDevice{}
+	for _, d := range devices {
+		byID[d.DeviceID] = d
+	}
+	d1 := byID["d1"]
+	if d1.DeviceName != "Phone" || d1.LastEvent != "SYNC_SUCCESS" || d1.LastStatus != "success" || d1.LastMessage != "done" {
+		t.Errorf("d1 = %+v", d1)
+	}
+	if tab := byID["Tablet"]; tab.DeviceName != "Tablet" || tab.LastStatus != "running" {
+		t.Errorf("tablet = %+v", tab)
+	}
+}
+
+func TestSyncRepo_Status(t *testing.T) {
+	db := newTestDB(t)
+	insertTestAPIKey(t, db, "key1")
+	repo := SyncRepo{log: zerolog.Nop(), db: db}
+	ctx := context.Background()
+
+	st, err := repo.GetStatus(ctx, "key1")
+	if err != nil || st != nil {
+		t.Fatalf("empty status = (%v, %v), want (nil, nil)", st, err)
+	}
+
+	eventAt := time.Now().Add(-time.Minute)
+	if err := repo.UpsertStatus(ctx, "key1", domain.SyncStatus{LastEventAt: &eventAt, LastEvent: "SYNC_FAILED", LastStatus: "error", LastDevice: "Phone", LastMessage: "boom"}); err != nil {
+		t.Fatal(err)
+	}
+	syncedAt := time.Now()
+	if err := repo.UpsertStatus(ctx, "key1", domain.SyncStatus{LastSyncedAt: &syncedAt}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.SetSyncData(ctx, "key1", []byte("12345")); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err = repo.GetStatus(ctx, "key1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.LastEvent != "SYNC_FAILED" || st.LastStatus != "error" || st.LastDevice != "Phone" || st.LastMessage != "boom" {
+		t.Errorf("content write cleared event fields: %+v", st)
+	}
+	if st.LastSyncedAt == nil || st.LastEventAt == nil || st.DataUpdatedAt == nil {
+		t.Errorf("timestamps missing: %+v", st)
+	}
+	if st.DataSize != 5 {
+		t.Errorf("data size = %d, want 5", st.DataSize)
+	}
+
+	// data only, no status row
+	insertTestAPIKey(t, db, "key2")
+	if _, err := repo.SetSyncData(ctx, "key2", []byte("ab")); err != nil {
+		t.Fatal(err)
+	}
+	st, err = repo.GetStatus(ctx, "key2")
+	if err != nil || st == nil || st.DataSize != 2 {
+		t.Errorf("data-only status = (%+v, %v)", st, err)
+	}
+}
+
+// Upgrading a database that is already at the previous schema version must only run the new migration.
+func TestSQLiteMigrationFromPreviousVersion(t *testing.T) {
+	databaseDriver = "sqlite"
+	db := &DB{
+		squirrel: sq.StatementBuilder.PlaceholderFormat(sq.Dollar),
+		log:      zerolog.Nop(),
+		Driver:   "sqlite",
+		DSN:      filepath.Join(t.TempDir(), "old.db"),
+	}
+	db.ctx, db.cancel = context.WithCancel(context.Background())
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := db.openSQLite(); err != nil {
+		t.Fatal(err)
+	}
+	// rewind to the previous version by dropping what the last migration added
+	previous := len(sqliteMigrations) - 1
+	for _, stmt := range []string{
+		"DROP TABLE sync_data_history", "DROP TABLE sync_device", "DROP TABLE sync_status",
+		fmt.Sprintf("PRAGMA user_version = %d", previous),
+	} {
+		if _, err := db.handler.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	insertTestAPIKey(t, db, "key1")
+	if _, err := db.handler.Exec(`INSERT INTO sync_data (user_api_key, data, data_etag) VALUES ('key1', X'01', 'uuid=old')`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.migrateSQLite(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	var version int
+	if err := db.handler.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != len(sqliteMigrations) {
+		t.Errorf("user_version = %d, want %d", version, len(sqliteMigrations))
+	}
+
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
+	ctx := context.Background()
+	data, etag, err := repo.GetSyncDataAndETag(ctx, "key1")
+	if err != nil || !bytes.Equal(data, []byte{1}) || *etag != "uuid=old" {
+		t.Errorf("existing data lost across migration: %v %v %v", data, etag, err)
+	}
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d"}, "", "", ""); err != nil {
+		t.Errorf("new table unusable after migration: %v", err)
+	}
+	if _, err := repo.SetSyncData(ctx, "key1", []byte{2}); err != nil {
+		t.Errorf("history write after migration: %v", err)
 	}
 }

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	PostgresPass      string `toml:"postgresPass"`
 	PostgresSslMode   string `toml:"postgresSslMode"`
 	SyncMaxBodySizeMB int    `toml:"syncMaxBodySizeMB"` // 0 = unlimited
+	SyncHistoryLimit  int    `toml:"syncHistoryLimit"`  // 0 = disabled
 }
 
 func (c *Config) SyncMaxBodyBytes() int64 {

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -2,17 +2,73 @@ package domain
 
 import (
 	"context"
+	"errors"
+	"time"
 )
 
+var ErrNotFound = errors.New("not found")
+
+type SyncHistoryEntry struct {
+	ID        int       `json:"id"`
+	ETag      string    `json:"etag"`
+	Size      int64     `json:"size"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type SyncDevice struct {
+	ID          int       `json:"id"`
+	DeviceID    string    `json:"device_id"`
+	DeviceName  string    `json:"device_name"`
+	LastSeen    time.Time `json:"last_seen"`
+	LastEvent   string    `json:"last_event"`
+	LastStatus  string    `json:"last_status"`
+	LastMessage string    `json:"last_message"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type SyncStatus struct {
+	LastSyncedAt  *time.Time `json:"last_synced_at"`
+	LastEventAt   *time.Time `json:"last_event_at"`
+	LastEvent     string     `json:"last_event"`
+	LastStatus    string     `json:"last_status"`
+	LastDevice    string     `json:"last_device"`
+	LastMessage   string     `json:"last_message"`
+	DataSize      int64      `json:"data_size"`
+	DataUpdatedAt *time.Time `json:"data_updated_at"`
+}
+
+// DeviceInfo is what a client optionally identifies itself with. All fields may be empty.
+type DeviceInfo struct {
+	ID   string
+	Name string
+}
+
+func (d DeviceInfo) Key() string {
+	if d.ID != "" {
+		return d.ID
+	}
+	return d.Name
+}
+
 type SyncRepo interface {
-	// Get etag of sync data.
-	// For avoid memory usage, only the etag will be returned.
+	// Returns (nil, nil) when no data exists.
 	GetSyncDataETag(ctx context.Context, apiKey string) (*string, error)
-	// Get sync data and etag
 	GetSyncDataAndETag(ctx context.Context, apiKey string) ([]byte, *string, error)
 	// Create or replace sync data, returns the new etag.
 	SetSyncData(ctx context.Context, apiKey string, data []byte) (*string, error)
-	// Replace sync data only if the etag matches,
-	// returns the new etag if updated, or nil if not.
+	// Returns the new etag if the stored etag matched, or (nil, nil) if not.
 	SetSyncDataIfMatch(ctx context.Context, apiKey string, etag string, data []byte) (*string, error)
+
+	ListHistory(ctx context.Context, apiKey string) ([]SyncHistoryEntry, error)
+	// Puts a history entry back as the current sync data and returns the new etag. ErrNotFound if id is unknown.
+	RestoreHistory(ctx context.Context, apiKey string, id int) (*string, error)
+
+	// Empty fields never overwrite stored values. No-op when dev has no ID and no Name.
+	TouchDevice(ctx context.Context, apiKey string, dev DeviceInfo, event, status, message string) error
+	ListDevices(ctx context.Context, apiKey string) ([]SyncDevice, error)
+
+	// Nil timestamps and empty strings never overwrite stored values.
+	UpsertStatus(ctx context.Context, apiKey string, st SyncStatus) error
+	// Returns (nil, nil) when nothing is known about the key.
+	GetStatus(ctx context.Context, apiKey string) (*SyncStatus, error)
 }

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -39,6 +39,20 @@ func (s Server) IsAuthenticated(next http.Handler) http.Handler {
 	})
 }
 
+// IsSessionAuthenticated only accepts the web UI session; API keys are rejected.
+func (s Server) IsSessionAuthenticated(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		session, _ := s.cookieStore.Get(r, "user_session")
+
+		if auth, ok := session.Values["authenticated"].(bool); !ok || !auth {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
 func LoggerMiddleware(logger *zerolog.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/middleware_test.go
+++ b/internal/http/middleware_test.go
@@ -19,7 +19,7 @@ type mockAPIKeyService struct {
 func (m *mockAPIKeyService) Get(ctx context.Context, key string) (*domain.APIKey, error) {
 	return nil, nil
 }
-func (m *mockAPIKeyService) List(ctx context.Context) ([]domain.APIKey, error)  { return nil, nil }
+func (m *mockAPIKeyService) List(ctx context.Context) ([]domain.APIKey, error)   { return nil, nil }
 func (m *mockAPIKeyService) Store(ctx context.Context, key *domain.APIKey) error { return nil }
 func (m *mockAPIKeyService) Update(ctx context.Context, key *domain.APIKey) error {
 	return nil
@@ -143,6 +143,58 @@ func TestServer_IsAuthenticated(t *testing.T) {
 			}
 			if len(api.calls) != len(tt.wantCalls) {
 				t.Errorf("ValidateAPIKey calls = %v, want %v", api.calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestServer_IsSessionAuthenticated(t *testing.T) {
+	const validKey = "valid-key"
+
+	tests := []struct {
+		name       string
+		header     string
+		session    string
+		wantStatus int
+	}{
+		{name: "valid api token is rejected", header: validKey, wantStatus: http.StatusUnauthorized},
+		{name: "no credentials is rejected", wantStatus: http.StatusUnauthorized},
+		{name: "authenticated session passes", session: "authed", wantStatus: http.StatusOK},
+		{name: "logged out session is rejected", session: "unauthed", wantStatus: http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &mockAPIKeyService{validKey: validKey}
+			cfg := &domain.Config{BaseURL: "/", SessionSecret: "test-secret"}
+			s := Server{apiService: api, cookieStore: newCookieStore(cfg)}
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.header != "" {
+				req.Header.Set("X-API-Token", tt.header)
+			}
+			if tt.session != "" {
+				sess, _ := s.cookieStore.Get(req, "user_session")
+				sess.Values["authenticated"] = tt.session == "authed"
+				w := httptest.NewRecorder()
+				if err := sess.Save(req, w); err != nil {
+					t.Fatalf("saving session: %v", err)
+				}
+				req.Header.Set("Cookie", w.Header().Get("Set-Cookie"))
+			}
+
+			rec := httptest.NewRecorder()
+			s.IsSessionAuthenticated(next).ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("IsSessionAuthenticated() status = %v, want %v", rec.Code, tt.wantStatus)
+			}
+			if len(api.calls) != 0 {
+				t.Errorf("ValidateAPIKey must not be consulted, calls = %v", api.calls)
 			}
 		})
 	}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -119,10 +119,17 @@ func (s Server) Handler() http.Handler {
 	r.Use(c.Handler)
 
 	encoder := encoder{}
+	syncHandler := newSyncHandler(encoder, s.log, s.syncService, s.config.Config.SyncMaxBodyBytes())
 
 	r.Route("/api", func(r chi.Router) {
 		r.Route("/auth", newAuthHandler(encoder, s.log, s.config.Config, s.cookieStore, s.authService).Routes)
 		r.Route("/healthz", newHealthHandler(encoder, s.db).Routes)
+
+		r.Group(func(r chi.Router) {
+			r.Use(s.IsSessionAuthenticated)
+
+			r.Route("/sync/admin", syncHandler.AdminRoutes)
+		})
 
 		r.Group(func(r chi.Router) {
 			r.Use(s.IsAuthenticated)
@@ -132,7 +139,7 @@ func (s Server) Handler() http.Handler {
 			r.Route("/logs", newLogsHandler(s.config).Routes)
 			r.Route("/notification", newNotificationHandler(encoder, s.notificationService).Routes)
 			r.Route("/updates", newUpdateHandler(encoder, s.updateService).Routes)
-			r.Route("/sync", newSyncHandler(encoder, s.log, s.syncService, s.config.Config.SyncMaxBodyBytes()).Routes)
+			r.Route("/sync", syncHandler.Routes)
 
 			r.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 

--- a/internal/http/sync.go
+++ b/internal/http/sync.go
@@ -1,13 +1,18 @@
 package http
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 
+	"github.com/SyncYomi/SyncYomi/internal/domain"
 	"github.com/SyncYomi/SyncYomi/internal/sync"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/render"
 	"github.com/rs/zerolog"
 )
 
@@ -32,14 +37,31 @@ func newSyncHandler(encoder encoder, log zerolog.Logger, syncService syncService
 // syncEventRequest is the body for POST /api/sync/event (device-reported sync status).
 type syncEventRequest struct {
 	Event      string `json:"event"`
+	DeviceID   string `json:"device_id"`
 	DeviceName string `json:"device_name"`
 	Message    string `json:"message"`
 }
 
+// Routes are the client-facing sync endpoints (API key auth).
 func (h syncHandler) Routes(r chi.Router) {
-	r.Get("/content", h.getContent)
+	r.With(middleware.Compress(5, "application/octet-stream")).Get("/content", h.getContent)
 	r.Put("/content", h.putContent)
 	r.Post("/event", h.reportEvent)
+}
+
+// AdminRoutes expose per-key status for the web UI and must be mounted behind session auth only.
+func (h syncHandler) AdminRoutes(r chi.Router) {
+	r.Get("/{apikey}/status", h.getStatus)
+	r.Get("/{apikey}/devices", h.listDevices)
+	r.Get("/{apikey}/history", h.listHistory)
+	r.Post("/{apikey}/history/{id}/restore", h.restoreHistory)
+}
+
+func deviceFromRequest(r *http.Request) domain.DeviceInfo {
+	return domain.DeviceInfo{
+		ID:   r.Header.Get("X-Device-ID"),
+		Name: r.Header.Get("X-Device-Name"),
+	}
 }
 
 func (h syncHandler) getContent(w http.ResponseWriter, r *http.Request) {
@@ -56,6 +78,7 @@ func (h syncHandler) getContent(w http.ResponseWriter, r *http.Request) {
 
 		if etagInDb != nil && etag == *etagInDb {
 			// see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
+			h.syncService.RecordContentAccess(r.Context(), apiKey, deviceFromRequest(r), false)
 			w.WriteHeader(http.StatusNotModified)
 			return
 		}
@@ -73,6 +96,8 @@ func (h syncHandler) getContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.syncService.RecordContentAccess(r.Context(), apiKey, deviceFromRequest(r), false)
+
 	if syncDataETag != nil {
 		w.Header().Set("ETag", *syncDataETag)
 	}
@@ -88,14 +113,10 @@ func (h syncHandler) putContent(w http.ResponseWriter, r *http.Request) {
 	apiKey := r.Header.Get("X-API-Token")
 	etag := r.Header.Get("If-Match")
 
-	if h.maxBodyBytes > 0 {
-		r.Body = http.MaxBytesReader(w, r.Body, h.maxBodyBytes)
-	}
-
-	requestData, err := io.ReadAll(r.Body)
+	requestData, err := h.readBody(w, r)
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
+		if errors.As(err, &maxBytesErr) || errors.Is(err, errBodyTooLarge) {
 			h.encoder.StatusResponse(r.Context(), w, map[string]string{"message": "request body too large"}, http.StatusRequestEntityTooLarge)
 			return
 		}
@@ -121,8 +142,42 @@ func (h syncHandler) putContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.syncService.RecordContentAccess(r.Context(), apiKey, deviceFromRequest(r), true)
+
 	w.Header().Set("ETag", *newEtag)
 	w.WriteHeader(http.StatusOK)
+}
+
+var errBodyTooLarge = errors.New("request body too large")
+
+func (h syncHandler) readBody(w http.ResponseWriter, r *http.Request) ([]byte, error) {
+	var body io.Reader = r.Body
+	if h.maxBodyBytes > 0 {
+		r.Body = http.MaxBytesReader(w, r.Body, h.maxBodyBytes)
+		body = r.Body
+	}
+
+	if r.Header.Get("Content-Encoding") == "gzip" {
+		gz, err := gzip.NewReader(body)
+		if err != nil {
+			return nil, err
+		}
+		defer gz.Close()
+		body = gz
+		if h.maxBodyBytes > 0 {
+			body = io.LimitReader(gz, h.maxBodyBytes+1)
+		}
+	}
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+	if h.maxBodyBytes > 0 && int64(len(data)) > h.maxBodyBytes {
+		return nil, errBodyTooLarge
+	}
+
+	return data, nil
 }
 
 func (h syncHandler) reportEvent(w http.ResponseWriter, r *http.Request) {
@@ -145,7 +200,15 @@ func (h syncHandler) reportEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.syncService.ReportSyncEvent(r.Context(), apiKey, body.Event, body.DeviceName, body.Message); err != nil {
+	dev := deviceFromRequest(r)
+	if dev.ID == "" {
+		dev.ID = body.DeviceID
+	}
+	if dev.Name == "" {
+		dev.Name = body.DeviceName
+	}
+
+	if err := h.syncService.ReportSyncEvent(r.Context(), apiKey, body.Event, dev, body.Message); err != nil {
 		if errors.Is(err, sync.ErrInvalidSyncEvent) {
 			h.encoder.StatusResponse(r.Context(), w, map[string]string{"message": "invalid sync event"}, http.StatusBadRequest)
 			return
@@ -156,4 +219,62 @@ func (h syncHandler) reportEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.encoder.NoContent(w)
+}
+
+func (h syncHandler) getStatus(w http.ResponseWriter, r *http.Request) {
+	status, err := h.syncService.GetStatus(r.Context(), chi.URLParam(r, "apikey"))
+	if err != nil {
+		h.log.Error().Err(err).Msg("failed to read sync status")
+		h.encoder.StatusInternalError(w)
+		return
+	}
+	if status == nil {
+		h.encoder.StatusNotFound(r.Context(), w)
+		return
+	}
+
+	render.JSON(w, r, status)
+}
+
+func (h syncHandler) listDevices(w http.ResponseWriter, r *http.Request) {
+	devices, err := h.syncService.ListDevices(r.Context(), chi.URLParam(r, "apikey"))
+	if err != nil {
+		h.log.Error().Err(err).Msg("failed to list devices")
+		h.encoder.StatusInternalError(w)
+		return
+	}
+
+	render.JSON(w, r, devices)
+}
+
+func (h syncHandler) listHistory(w http.ResponseWriter, r *http.Request) {
+	history, err := h.syncService.ListHistory(r.Context(), chi.URLParam(r, "apikey"))
+	if err != nil {
+		h.log.Error().Err(err).Msg("failed to list sync history")
+		h.encoder.StatusInternalError(w)
+		return
+	}
+
+	render.JSON(w, r, history)
+}
+
+func (h syncHandler) restoreHistory(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		h.encoder.StatusResponse(r.Context(), w, map[string]string{"message": "invalid history id"}, http.StatusBadRequest)
+		return
+	}
+
+	etag, err := h.syncService.RestoreHistory(r.Context(), chi.URLParam(r, "apikey"), id)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			h.encoder.StatusNotFound(r.Context(), w)
+			return
+		}
+		h.log.Error().Err(err).Msg("failed to restore sync history")
+		h.encoder.StatusInternalError(w)
+		return
+	}
+
+	render.JSON(w, r, map[string]string{"etag": *etag})
 }

--- a/internal/http/sync_test.go
+++ b/internal/http/sync_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/SyncYomi/SyncYomi/internal/domain"
 	"github.com/SyncYomi/SyncYomi/internal/sync"
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog"
@@ -22,9 +24,21 @@ type mockSyncService struct {
 	getDataETag        *string
 	setDataErr         error
 	setDataEtag        *string
+	onSetData          func(data []byte)
 	setDataIfMatchErr  error
 	setDataIfMatchEtag *string
 	reportEventErr     error
+
+	reportedDevice domain.DeviceInfo
+	accessDevice   domain.DeviceInfo
+	accessWrite    bool
+	accessCalls    int
+
+	adminErr    error
+	history     []domain.SyncHistoryEntry
+	devices     []domain.SyncDevice
+	status      *domain.SyncStatus
+	restoreEtag *string
 }
 
 func (m *mockSyncService) GetSyncDataETag(ctx context.Context, apiKey string) (*string, error) {
@@ -45,6 +59,9 @@ func (m *mockSyncService) SetSyncData(ctx context.Context, apiKey string, data [
 	if m.setDataErr != nil {
 		return nil, m.setDataErr
 	}
+	if m.onSetData != nil {
+		m.onSetData(data)
+	}
 	return m.setDataEtag, nil
 }
 
@@ -55,8 +72,37 @@ func (m *mockSyncService) SetSyncDataIfMatch(ctx context.Context, apiKey string,
 	return m.setDataIfMatchEtag, nil
 }
 
-func (m *mockSyncService) ReportSyncEvent(ctx context.Context, apiKey string, event string, deviceName string, detailMessage string) error {
+func (m *mockSyncService) ReportSyncEvent(ctx context.Context, apiKey string, event string, dev domain.DeviceInfo, detailMessage string) error {
+	m.reportedDevice = dev
 	return m.reportEventErr
+}
+
+func (m *mockSyncService) RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool) {
+	m.accessDevice = dev
+	m.accessWrite = write
+	m.accessCalls++
+}
+
+func (m *mockSyncService) ListHistory(ctx context.Context, apiKey string) ([]domain.SyncHistoryEntry, error) {
+	return m.history, m.adminErr
+}
+
+func (m *mockSyncService) RestoreHistory(ctx context.Context, apiKey string, id int) (*string, error) {
+	if m.adminErr != nil {
+		return nil, m.adminErr
+	}
+	if m.restoreEtag == nil {
+		return nil, domain.ErrNotFound
+	}
+	return m.restoreEtag, nil
+}
+
+func (m *mockSyncService) ListDevices(ctx context.Context, apiKey string) ([]domain.SyncDevice, error) {
+	return m.devices, m.adminErr
+}
+
+func (m *mockSyncService) GetStatus(ctx context.Context, apiKey string) (*domain.SyncStatus, error) {
+	return m.status, m.adminErr
 }
 
 func TestSyncHandler_getContent(t *testing.T) {
@@ -231,6 +277,165 @@ func TestSyncHandler_putContentBodyLimit(t *testing.T) {
 			t.Errorf("status = %v, want 413", rec.Code)
 		}
 	})
+
+	t.Run("gzip body over limit after inflation is rejected with 413", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/content", bytes.NewReader(gzipBytes(t, make([]byte, 1024))))
+		req.Header.Set("X-API-Token", "key1")
+		req.Header.Set("Content-Encoding", "gzip")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusRequestEntityTooLarge {
+			t.Errorf("status = %v, want 413", rec.Code)
+		}
+	})
+}
+
+func TestSyncHandler_putContentGzip(t *testing.T) {
+	enc := encoder{}
+	var stored []byte
+	mock := &mockSyncService{setDataEtag: strPtr("etag-new")}
+	mock.onSetData = func(data []byte) { stored = data }
+	r := chi.NewRouter()
+	r.Route("/", func(r chi.Router) {
+		newSyncHandler(enc, zerolog.Nop(), mock, 0).Routes(r)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, "/content", bytes.NewReader(gzipBytes(t, []byte("plain-payload"))))
+	req.Header.Set("X-API-Token", "key1")
+	req.Header.Set("Content-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %v, want 200", rec.Code)
+	}
+	if !bytes.Equal(stored, []byte("plain-payload")) {
+		t.Errorf("stored = %q, want inflated payload", stored)
+	}
+}
+
+func TestSyncHandler_deviceHeaders(t *testing.T) {
+	enc := encoder{}
+	mock := &mockSyncService{setDataEtag: strPtr("etag-new")}
+	r := chi.NewRouter()
+	r.Route("/", func(r chi.Router) {
+		newSyncHandler(enc, zerolog.Nop(), mock, 0).Routes(r)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, "/content", bytes.NewReader([]byte("x")))
+	req.Header.Set("X-API-Token", "key1")
+	req.Header.Set("X-Device-ID", "dev-1")
+	req.Header.Set("X-Device-Name", "Phone")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %v, want 200", rec.Code)
+	}
+	if mock.accessCalls != 1 || !mock.accessWrite {
+		t.Errorf("RecordContentAccess calls=%d write=%v, want 1/true", mock.accessCalls, mock.accessWrite)
+	}
+	if mock.accessDevice != (domain.DeviceInfo{ID: "dev-1", Name: "Phone"}) {
+		t.Errorf("device = %+v", mock.accessDevice)
+	}
+
+	// event: body fields are used when headers are absent
+	body, _ := json.Marshal(map[string]string{"event": "SYNC_SUCCESS", "device_id": "dev-2", "device_name": "Tablet"})
+	req = httptest.NewRequest(http.MethodPost, "/event", bytes.NewReader(body))
+	req.Header.Set("X-API-Token", "key1")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("event status = %v, want 204", rec.Code)
+	}
+	if mock.reportedDevice != (domain.DeviceInfo{ID: "dev-2", Name: "Tablet"}) {
+		t.Errorf("event device = %+v", mock.reportedDevice)
+	}
+}
+
+func TestSyncHandler_adminRoutes(t *testing.T) {
+	enc := encoder{}
+	newRouter := func(mock *mockSyncService) *chi.Mux {
+		r := chi.NewRouter()
+		r.Route("/", func(r chi.Router) {
+			newSyncHandler(enc, zerolog.Nop(), mock, 0).AdminRoutes(r)
+		})
+		return r
+	}
+
+	t.Run("status 404 when unknown", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		newRouter(&mockSyncService{}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/key1/status", nil))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("status = %v, want 404", rec.Code)
+		}
+	})
+
+	t.Run("status returns json", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		newRouter(&mockSyncService{status: &domain.SyncStatus{LastStatus: "success", DataSize: 42}}).
+			ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/key1/status", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %v, want 200", rec.Code)
+		}
+		var got domain.SyncStatus
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.LastStatus != "success" || got.DataSize != 42 {
+			t.Errorf("body = %+v", got)
+		}
+	})
+
+	t.Run("devices and history return arrays", func(t *testing.T) {
+		mock := &mockSyncService{
+			devices: []domain.SyncDevice{{DeviceID: "d1"}},
+			history: []domain.SyncHistoryEntry{{ID: 7, ETag: "e"}},
+		}
+		for _, path := range []string{"/key1/devices", "/key1/history"} {
+			rec := httptest.NewRecorder()
+			newRouter(mock).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+			if rec.Code != http.StatusOK {
+				t.Errorf("%s status = %v, want 200", path, rec.Code)
+			}
+			if !bytes.HasPrefix(bytes.TrimSpace(rec.Body.Bytes()), []byte("[")) {
+				t.Errorf("%s body = %q, want array", path, rec.Body.String())
+			}
+		}
+	})
+
+	t.Run("restore", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		newRouter(&mockSyncService{}).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/key1/history/1/restore", nil))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("unknown id status = %v, want 404", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		newRouter(&mockSyncService{}).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/key1/history/abc/restore", nil))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("bad id status = %v, want 400", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		newRouter(&mockSyncService{restoreEtag: strPtr("etag-r")}).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/key1/history/1/restore", nil))
+		if rec.Code != http.StatusOK || !bytes.Contains(rec.Body.Bytes(), []byte("etag-r")) {
+			t.Errorf("restore = %v %q, want 200 with etag", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func gzipBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
 }
 
 func TestSyncHandler_reportEvent(t *testing.T) {

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -16,18 +16,22 @@ import (
 var ErrInvalidSyncEvent = errors.New("invalid sync event")
 
 type Service interface {
-	// Get etag of sync data.
-	// For avoid memory usage, only the etag will be returnedj
+	// Returns (nil, nil) when no data exists.
 	GetSyncDataETag(ctx context.Context, apiKey string) (*string, error)
-	// Get sync data and etag
 	GetSyncDataAndETag(ctx context.Context, apiKey string) ([]byte, *string, error)
 	// Create or replace sync data, returns the new etag.
 	SetSyncData(ctx context.Context, apiKey string, data []byte) (*string, error)
-	// Replace sync data only if the etag matches,
-	// returns the new etag if updated, or nil if not.
+	// Returns the new etag if the stored etag matched, or (nil, nil) if not.
 	SetSyncDataIfMatch(ctx context.Context, apiKey string, etag string, data []byte) (*string, error)
-	// ReportSyncEvent sends a device-reported sync event to the notification service.
-	ReportSyncEvent(ctx context.Context, apiKey string, event string, deviceName string, detailMessage string) error
+	// ReportSyncEvent persists a device-reported sync event and sends it to the notification service.
+	ReportSyncEvent(ctx context.Context, apiKey string, event string, dev domain.DeviceInfo, detailMessage string) error
+	// RecordContentAccess updates device/status bookkeeping after a successful GET or PUT of the content. Errors are logged, not returned.
+	RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool)
+
+	ListHistory(ctx context.Context, apiKey string) ([]domain.SyncHistoryEntry, error)
+	RestoreHistory(ctx context.Context, apiKey string, id int) (*string, error)
+	ListDevices(ctx context.Context, apiKey string) ([]domain.SyncDevice, error)
+	GetStatus(ctx context.Context, apiKey string) (*domain.SyncStatus, error)
 }
 
 func NewService(log logger.Logger, repo domain.SyncRepo, notificationSvc notification.Service, apiRepo domain.APIRepo) Service {
@@ -46,38 +50,79 @@ type service struct {
 	apiRepo             domain.APIRepo
 }
 
-// Get etag of sync data.
-// For avoid memory usage, only the etag will be returned.
 func (s service) GetSyncDataETag(ctx context.Context, apiKey string) (*string, error) {
 	return s.repo.GetSyncDataETag(ctx, apiKey)
 }
 
-// Get sync data and etag
 func (s service) GetSyncDataAndETag(ctx context.Context, apiKey string) ([]byte, *string, error) {
 	return s.repo.GetSyncDataAndETag(ctx, apiKey)
 }
 
-// Create or replace sync data, returns the new etag.
 func (s service) SetSyncData(ctx context.Context, apiKey string, data []byte) (*string, error) {
 	return s.repo.SetSyncData(ctx, apiKey, data)
 }
 
-// Replace sync data only if the etag matches,
-// returns the new etag if updated, or nil if not.
 func (s service) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag string, data []byte) (*string, error) {
 	return s.repo.SetSyncDataIfMatch(ctx, apiKey, etag, data)
 }
 
-func (s service) ReportSyncEvent(ctx context.Context, apiKey string, event string, deviceName string, detailMessage string) error {
+func (s service) ListHistory(ctx context.Context, apiKey string) ([]domain.SyncHistoryEntry, error) {
+	return s.repo.ListHistory(ctx, apiKey)
+}
+
+func (s service) RestoreHistory(ctx context.Context, apiKey string, id int) (*string, error) {
+	return s.repo.RestoreHistory(ctx, apiKey, id)
+}
+
+func (s service) ListDevices(ctx context.Context, apiKey string) ([]domain.SyncDevice, error) {
+	return s.repo.ListDevices(ctx, apiKey)
+}
+
+func (s service) GetStatus(ctx context.Context, apiKey string) (*domain.SyncStatus, error) {
+	return s.repo.GetStatus(ctx, apiKey)
+}
+
+func (s service) RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool) {
+	if err := s.repo.TouchDevice(ctx, apiKey, dev, "", "", ""); err != nil {
+		s.log.Warn().Err(err).Msg("failed to record device")
+	}
+
+	if !write {
+		return
+	}
+
+	now := time.Now()
+	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{LastSyncedAt: &now, LastDevice: dev.Name}); err != nil {
+		s.log.Warn().Err(err).Msg("failed to record sync status")
+	}
+}
+
+func (s service) ReportSyncEvent(ctx context.Context, apiKey string, event string, dev domain.DeviceInfo, detailMessage string) error {
 	ev, err := parseSyncEvent(event)
 	if err != nil {
 		return err
 	}
+
+	now := time.Now()
+	status := statusFromEvent(ev)
+	if err := s.repo.TouchDevice(ctx, apiKey, dev, event, status, detailMessage); err != nil {
+		s.log.Warn().Err(err).Msg("failed to record device")
+	}
+	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{
+		LastEventAt: &now,
+		LastEvent:   event,
+		LastStatus:  status,
+		LastDevice:  dev.Name,
+		LastMessage: detailMessage,
+	}); err != nil {
+		s.log.Warn().Err(err).Msg("failed to record sync status")
+	}
+
 	keyName := "Unknown"
 	if key, err := s.apiRepo.Get(ctx, apiKey); err == nil && key != nil && key.Name != "" {
 		keyName = key.Name
 	}
-	payload := s.buildSyncPayload(ev, keyName, deviceName, detailMessage)
+	payload := s.buildSyncPayload(ev, keyName, dev.Name, detailMessage)
 	s.notificationService.Send(ev, payload)
 	return nil
 }
@@ -96,6 +141,21 @@ func parseSyncEvent(event string) (domain.NotificationEvent, error) {
 		return domain.NotificationEventSyncCancelled, nil
 	default:
 		return "", ErrInvalidSyncEvent
+	}
+}
+
+func statusFromEvent(ev domain.NotificationEvent) string {
+	switch ev {
+	case domain.NotificationEventSyncStarted:
+		return "running"
+	case domain.NotificationEventSyncSuccess:
+		return "success"
+	case domain.NotificationEventSyncFailed, domain.NotificationEventSyncError:
+		return "error"
+	case domain.NotificationEventSyncCancelled:
+		return "cancelled"
+	default:
+		return ""
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 		apikeyRepo       = database.NewAPIRepo(log, db)
 		notificationRepo = database.NewNotificationRepo(log, db)
 		userRepo         = database.NewUserRepo(log, db)
-		syncRepo         = database.NewSyncRepo(log, db)
+		syncRepo         = database.NewSyncRepo(log, db, cfg.Config.SyncHistoryLimit)
 	)
 
 	// setup services

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -86,6 +86,18 @@ export const APIClient = {
     create: (key: APIKey) => appClient.Post("api/keys", key),
     delete: (key: string) => appClient.Delete(`api/keys/${key}`),
   },
+  sync: {
+    status: (key: string) =>
+      appClient.Get<SyncStatus>(`api/sync/admin/${key}/status`),
+    devices: (key: string) =>
+      appClient.Get<SyncDevice[]>(`api/sync/admin/${key}/devices`),
+    history: (key: string) =>
+      appClient.Get<SyncHistoryEntry[]>(`api/sync/admin/${key}/history`),
+    restore: (key: string, id: number) =>
+      appClient.Post<{ etag: string }>(
+        `api/sync/admin/${key}/history/${id}/restore`,
+      ),
+  },
   config: {
     get: () => appClient.Get<Config>("api/config"),
     update: (config: ConfigUpdate) => appClient.Patch("api/config", config),

--- a/web/src/components/settings/ApiKeySettings.vue
+++ b/web/src/components/settings/ApiKeySettings.vue
@@ -27,37 +27,59 @@
           <tr>
             <th class="text-left">Name</th>
             <th class="text-left">Key</th>
+            <th class="text-left">Sync</th>
           </tr>
         </thead>
         <tbody v-if="data && dataTableComputed.length > 0">
-          <tr v-for="(item, index) in dataTableComputed" :key="index">
-            <td>{{ item.name }}</td>
-            <td>
-              <v-text-field
-                variant="underlined"
-                :model-value="item.key"
-                :readonly="true"
-                :type="showPassword[index] ? 'text' : 'password'"
-              >
-                <template #append-inner>
-                  <v-icon class="mr-2" @click="togglePasswordVisibility(index)">
-                    mdi-eye{{ showPassword[index] ? "-off" : "" }}
-                  </v-icon>
-                  <v-icon class="mr-2" @click="showQrCode(item.key)">
-                    mdi-qrcode
-                  </v-icon>
-                  <v-icon @click="copyToClipboard(item.key)">
-                    mdi-content-copy
-                  </v-icon>
-                </template>
-                <template #append>
-                  <v-icon @click="showDeleteConfirmation(item.key)"
-                    >mdi-file-document-remove
-                  </v-icon>
-                </template>
-              </v-text-field>
-            </td>
-          </tr>
+          <template v-for="(item, index) in dataTableComputed" :key="index">
+            <tr>
+              <td>{{ item.name }}</td>
+              <td>
+                <v-text-field
+                  variant="underlined"
+                  :model-value="item.key"
+                  :readonly="true"
+                  :type="showPassword[index] ? 'text' : 'password'"
+                >
+                  <template #append-inner>
+                    <v-icon class="mr-2" @click="togglePasswordVisibility(index)">
+                      mdi-eye{{ showPassword[index] ? "-off" : "" }}
+                    </v-icon>
+                    <v-icon class="mr-2" @click="showQrCode(item.key)">
+                      mdi-qrcode
+                    </v-icon>
+                    <v-icon @click="copyToClipboard(item.key)">
+                      mdi-content-copy
+                    </v-icon>
+                  </template>
+                  <template #append>
+                    <v-icon @click="showDeleteConfirmation(item.key)"
+                      >mdi-file-document-remove
+                    </v-icon>
+                  </template>
+                </v-text-field>
+              </td>
+              <td>
+                <v-btn
+                  size="small"
+                  variant="text"
+                  :append-icon="expandedKey === item.key ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                  @click="toggleDetails(item.key)"
+                >
+                  Details
+                </v-btn>
+              </td>
+            </tr>
+            <tr v-if="expandedKey === item.key">
+              <td colspan="3" class="pa-0">
+                <sync-key-details
+                  :api-key="item.key"
+                  @restored="onRestored"
+                  @error="onDetailsError"
+                />
+              </td>
+            </tr>
+          </template>
         </tbody>
       </v-table>
     </div>
@@ -90,10 +112,30 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 import ConfirmationModal from "@/components/modals/DeleteConfirmationModal.vue";
 import QrCodeModal from "@/components/modals/ShowQRCode.vue";
 import AddApiKey from "@/components/modals/AddApiKey.vue";
+import SyncKeyDetails from "@/components/settings/SyncKeyDetails.vue";
 
 interface ShowPassword {
   [index: number]: boolean;
 }
+
+const expandedKey: Ref<string | null> = ref(null);
+
+const toggleDetails = (key: string) => {
+  expandedKey.value = expandedKey.value === key ? null : key;
+};
+
+const onRestored = () => {
+  snackbarVisible.value = true;
+  snackbarMessage.value = "Sync data restored!";
+  snackbarColor.value = "success";
+};
+
+const onDetailsError = (message: string) => {
+  console.error("Sync details error:", message);
+  snackbarVisible.value = true;
+  snackbarMessage.value = "Error restoring sync data!";
+  snackbarColor.value = "error";
+};
 
 const snackbarVisible: Ref<boolean> = ref(false);
 const snackbarMessage: Ref<string> = ref("Config updated successfully!");

--- a/web/src/components/settings/SyncKeyDetails.vue
+++ b/web/src/components/settings/SyncKeyDetails.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="pa-4">
+    <v-row>
+      <v-col cols="12" md="4">
+        <h4 class="mb-2">Status</h4>
+        <div v-if="statusQuery.isLoading.value">Loading…</div>
+        <div v-else-if="!status">No sync recorded yet.</div>
+        <v-list v-else density="compact">
+          <v-list-item>
+            <v-list-item-title>Last upload</v-list-item-title>
+            <v-list-item-subtitle>{{ fmt(status.last_synced_at) }}</v-list-item-subtitle>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-title>Last event</v-list-item-title>
+            <v-list-item-subtitle>
+              <v-chip
+                v-if="status.last_status"
+                :color="statusColor(status.last_status)"
+                size="x-small"
+                class="mr-1"
+              >
+                {{ status.last_status }}
+              </v-chip>
+              {{ status.last_event || "—" }}
+              <span v-if="status.last_device"> · {{ status.last_device }}</span>
+              <span v-if="status.last_event_at"> · {{ fmt(status.last_event_at) }}</span>
+            </v-list-item-subtitle>
+          </v-list-item>
+          <v-list-item v-if="status.last_message">
+            <v-list-item-title>Message</v-list-item-title>
+            <v-list-item-subtitle>{{ status.last_message }}</v-list-item-subtitle>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-title>Stored payload</v-list-item-title>
+            <v-list-item-subtitle>
+              {{ formatBytes(status.data_size) }}
+              <span v-if="status.data_updated_at"> · {{ fmt(status.data_updated_at) }}</span>
+            </v-list-item-subtitle>
+          </v-list-item>
+        </v-list>
+      </v-col>
+
+      <v-col cols="12" md="4">
+        <h4 class="mb-2">Devices</h4>
+        <div v-if="devicesQuery.isLoading.value">Loading…</div>
+        <div v-else-if="!devices.length">
+          No devices seen yet. Devices appear once they report sync events.
+        </div>
+        <v-list v-else density="compact">
+          <v-list-item v-for="device in devices" :key="device.id">
+            <v-list-item-title>
+              {{ device.device_name || device.device_id }}
+              <v-chip
+                v-if="device.last_status"
+                :color="statusColor(device.last_status)"
+                size="x-small"
+                class="ml-1"
+              >
+                {{ device.last_status }}
+              </v-chip>
+            </v-list-item-title>
+            <v-list-item-subtitle>
+              Last seen {{ fmt(device.last_seen) }}
+              <span v-if="device.last_event"> · {{ device.last_event }}</span>
+            </v-list-item-subtitle>
+          </v-list-item>
+        </v-list>
+      </v-col>
+
+      <v-col cols="12" md="4">
+        <h4 class="mb-2">History</h4>
+        <div v-if="historyQuery.isLoading.value">Loading…</div>
+        <div v-else-if="!history.length">No previous payloads kept.</div>
+        <v-list v-else density="compact">
+          <v-list-item v-for="(entry, index) in history" :key="entry.id">
+            <v-list-item-title>
+              {{ fmt(entry.created_at) }}
+              <v-chip v-if="index === 0" size="x-small" class="ml-1">current</v-chip>
+            </v-list-item-title>
+            <v-list-item-subtitle>{{ formatBytes(entry.size) }}</v-list-item-subtitle>
+            <template #append>
+              <v-btn
+                v-if="index !== 0"
+                size="small"
+                variant="text"
+                :loading="restore.isPending.value && restoringId === entry.id"
+                @click="askRestore(entry.id)"
+              >
+                Restore
+              </v-btn>
+            </template>
+          </v-list-item>
+        </v-list>
+      </v-col>
+    </v-row>
+
+    <confirmation-modal
+      ref="restoreConfirmationModal"
+      title="Restore sync data"
+      message="Replace the current sync data with this earlier version? Devices will download it on their next sync."
+      @confirmed="confirmedRestore"
+      @canceled="restoringId = null"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
+import { APIClient } from "@/api/APIClient";
+import ConfirmationModal from "@/components/modals/DeleteConfirmationModal.vue";
+
+const props = defineProps<{ apiKey: string }>();
+const emit = defineEmits<{
+  (e: "restored"): void;
+  (e: "error", message: string): void;
+}>();
+
+const queryClient = useQueryClient();
+const restoreConfirmationModal = ref<InstanceType<typeof ConfirmationModal> | null>(
+  null,
+);
+const restoringId = ref<number | null>(null);
+
+const statusQuery = useQuery({
+  queryKey: ["syncStatus", props.apiKey],
+  queryFn: () => APIClient.sync.status(props.apiKey).catch(() => null),
+  retry: false,
+  refetchOnWindowFocus: false,
+});
+const devicesQuery = useQuery({
+  queryKey: ["syncDevices", props.apiKey],
+  queryFn: () => APIClient.sync.devices(props.apiKey),
+  retry: false,
+  refetchOnWindowFocus: false,
+});
+const historyQuery = useQuery({
+  queryKey: ["syncHistory", props.apiKey],
+  queryFn: () => APIClient.sync.history(props.apiKey),
+  retry: false,
+  refetchOnWindowFocus: false,
+});
+
+const status = computed(() => statusQuery.data.value ?? null);
+const devices = computed(() => devicesQuery.data.value ?? []);
+const history = computed(() => historyQuery.data.value ?? []);
+
+const restore = useMutation({
+  mutationFn: (id: number) => APIClient.sync.restore(props.apiKey, id),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ["syncStatus", props.apiKey] });
+    queryClient.invalidateQueries({ queryKey: ["syncHistory", props.apiKey] });
+    emit("restored");
+  },
+  onError: (error: Error) => emit("error", error.message),
+  onSettled: () => {
+    restoringId.value = null;
+  },
+});
+
+const askRestore = (id: number) => {
+  restoringId.value = id;
+  restoreConfirmationModal.value?.showModal();
+};
+
+const confirmedRestore = () => {
+  if (restoringId.value !== null) {
+    restore.mutate(restoringId.value);
+  }
+};
+
+const fmt = (value: string | null | undefined) =>
+  value ? new Date(value).toLocaleString() : "—";
+
+const formatBytes = (bytes: number) => {
+  if (!bytes) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+};
+
+const statusColor = (s: string) => {
+  switch (s) {
+    case "success":
+      return "success";
+    case "error":
+      return "error";
+    case "running":
+      return "info";
+    case "cancelled":
+      return "warning";
+    default:
+      return undefined;
+  }
+};
+</script>
+
+<style scoped></style>

--- a/web/src/types/API.d.ts
+++ b/web/src/types/API.d.ts
@@ -4,3 +4,32 @@ interface APIKey {
   scopes: string[];
   created_at: Date;
 }
+
+interface SyncStatus {
+  last_synced_at: string | null;
+  last_event_at: string | null;
+  last_event: string;
+  last_status: "" | "running" | "success" | "error" | "cancelled";
+  last_device: string;
+  last_message: string;
+  data_size: number;
+  data_updated_at: string | null;
+}
+
+interface SyncDevice {
+  id: number;
+  device_id: string;
+  device_name: string;
+  last_seen: string;
+  last_event: string;
+  last_status: string;
+  last_message: string;
+  created_at: string;
+}
+
+interface SyncHistoryEntry {
+  id: number;
+  etag: string;
+  size: number;
+  created_at: string;
+}


### PR DESCRIPTION
Keeps the last sync payloads per API key with restore from the web UI, records devices and last sync status, accepts gzip uploads and fixes OpenAPI.yaml to match the real endpoints.