### PR TITLE
fix(sync): dedupe repeated keys before writing a merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test
+.PHONY: test proto proto-check
 .POSIX:
 .SUFFIXES:
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -5,10 +5,10 @@ the combinations behave.
 
 ## Compatibility
 
-| Client | Server < 1.3 | Server ≥ 1.3 |
-|---|---|---|
-| v1 client (`GET`/`PUT /sync/content`) | works, client-side merge | works, server-side merge, deprecated |
-| v2 client | falls back to v1 (capabilities returns 404) | v2 |
+| Client                                | Server < 1.3                                | Server ≥ 1.3                         |
+| ------------------------------------- | ------------------------------------------- | ------------------------------------ |
+| v1 client (`GET`/`PUT /sync/content`) | works, client-side merge                    | works, server-side merge, deprecated |
+| v2 client                             | falls back to v1 (capabilities returns 404) | v2                                   |
 
 A library can be shared by v1 and v2 clients at the same time.
 
@@ -28,6 +28,7 @@ A library can be shared by v1 and v2 clients at the same time.
    Send the whole library with `X-Sync-Full: true` on the first sync, when your cursor is 0,
    when the last response carried `X-Sync-Full-Requested`, and occasionally (once a day) as a
    safety net.
+
 4. **Track deletions**: when the user deletes a category, remember its `uid` and send the
    pending uids in `X-Sync-Deleted-Categories`; clear them after a 200.
 5. **`POST /api/sync/v2/merge`** with `X-Sync-Cursor` = the cursor from the last response.
@@ -38,6 +39,10 @@ A library can be shared by v1 and v2 clients at the same time.
 7. **Report** `POST /api/sync/event` as before.
 
 Keep the v1 code path for old servers; it is unchanged.
+
+Give every scalar field of our backup models a default (`0`, `""`, `false`): protobuf
+omits zero values, and other clients (Suwayomi) never send them, so a model that requires
+them fails to decode a library that originated elsewhere.
 
 ### TachiyomiSY specifics
 

--- a/internal/backup/adapter.go
+++ b/internal/backup/adapter.go
@@ -122,7 +122,31 @@ func Split(b *pb.Backup) ([]*merge.Item, error) {
 		items = append(items, &merge.Item{Kind: merge.KindExtra, Key: merge.ExtraItemKey, Payload: append([]byte(nil), extra...)})
 	}
 
-	return items, nil
+	return dedupe(items), nil
+}
+
+// dedupe keeps one item per (kind, key): backups can repeat a chapter url or a category,
+// and a single write must not touch the same row twice. The highest version wins, ties go
+// to the later occurrence.
+func dedupe(items []*merge.Item) []*merge.Item {
+	type id struct {
+		kind merge.Kind
+		key  string
+	}
+	index := make(map[id]int, len(items))
+	out := items[:0]
+	for _, it := range items {
+		k := id{it.Kind, it.Key}
+		if i, ok := index[k]; ok {
+			if it.Version >= out[i].Version {
+				out[i] = it
+			}
+			continue
+		}
+		index[k] = len(out)
+		out = append(out, it)
+	}
+	return out
 }
 
 // Render assembles a Backup from items. Tombstoned categories are skipped and manga

--- a/internal/backup/adapter_test.go
+++ b/internal/backup/adapter_test.go
@@ -149,3 +149,33 @@ func mustEncode(t *testing.T, m proto.Message) []byte {
 	}
 	return data
 }
+
+func TestSplitDedupesRepeatedKeys(t *testing.T) {
+	b := &pb.Backup{
+		BackupCategories: []*pb.BackupCategory{{Name: "A", Uid: 1, Version: 1}, {Name: "A renamed", Uid: 1, Version: 2}},
+		BackupManga: []*pb.BackupManga{
+			{Source: 1, Url: "/m", Version: 3, Chapters: []*pb.BackupChapter{{Url: "/c", Version: 1}, {Url: "/c", Version: 5, Read: true}, {Url: "/c", Version: 2}}},
+			{Source: 1, Url: "/m", Version: 1},
+		},
+		BackupPreferences: []*pb.BackupPreference{{Key: "k", Value: &pb.PreferenceValue{Type: "x"}}, {Key: "k", Value: &pb.PreferenceValue{Type: "y"}}},
+	}
+	items, err := Split(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]*merge.Item{}
+	for _, it := range items {
+		id := string(it.Kind) + "|" + it.Key
+		if seen[id] != nil {
+			t.Errorf("duplicate item %s", id)
+		}
+		seen[id] = it
+	}
+	if seen["category|uid:1"].Version != 2 || seen["manga|1|/m"].Version != 3 || seen["chapter|"+ChapterKey("1|/m", "/c")].Version != 5 {
+		t.Errorf("highest version not kept: %+v", seen)
+	}
+	p := &pb.BackupPreference{}
+	if err := proto.Unmarshal(seen["app_pref|k"].Payload, p); err != nil || p.Value.Type != "y" {
+		t.Errorf("later occurrence not kept for ties: %v %v", p, err)
+	}
+}

--- a/internal/backup/codec_test.go
+++ b/internal/backup/codec_test.go
@@ -218,3 +218,53 @@ func TestScrubRemovesText(t *testing.T) {
 		t.Error("Scrub must not modify its input")
 	}
 }
+
+// kotlinx always writes the polymorphic preference payload, even when empty; a client
+// cannot decode a preference whose payload went missing on the server.
+func TestEmptyPreferencePayloadIsPreserved(t *testing.T) {
+	var value []byte
+	value = protowire.AppendTag(value, 1, protowire.BytesType)
+	value = protowire.AppendString(value, "eu.kanade.tachiyomi.data.backup.models.StringPreferenceValue")
+	value = protowire.AppendTag(value, 2, protowire.BytesType)
+	value = protowire.AppendBytes(value, nil) // 12 00
+
+	var pref []byte
+	pref = protowire.AppendTag(pref, 1, protowire.BytesType)
+	pref = protowire.AppendString(pref, "theme")
+	pref = protowire.AppendTag(pref, 2, protowire.BytesType)
+	pref = protowire.AppendBytes(pref, value)
+
+	var raw []byte
+	raw = protowire.AppendTag(raw, 104, protowire.BytesType)
+	raw = protowire.AppendBytes(raw, pref)
+
+	b, err := Decode(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.BackupPreferences[0].Value.Value == nil {
+		t.Fatal("empty payload decoded as absent")
+	}
+
+	check := func(name string, out *pb.Backup) {
+		enc, err := Encode(out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Contains(enc, []byte{0x12, 0x00}) {
+			t.Errorf("%s: empty preference payload dropped: %x", name, enc)
+		}
+	}
+	check("encode", b)
+
+	items, err := Split(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := Render(items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	check("split+render", rendered)
+	check("scrub", Scrub(b))
+}

--- a/internal/backup/codec_test.go
+++ b/internal/backup/codec_test.go
@@ -266,5 +266,9 @@ func TestEmptyPreferencePayloadIsPreserved(t *testing.T) {
 		t.Fatal(err)
 	}
 	check("split+render", rendered)
-	check("scrub", Scrub(b))
+
+	// scrubbing rewrites string payloads, but must keep the element present
+	if Scrub(b).BackupPreferences[0].Value.Value == nil {
+		t.Error("scrub dropped the preference payload")
+	}
 }

--- a/internal/backup/pb/backup.pb.go
+++ b/internal/backup/pb/backup.pb.go
@@ -1041,7 +1041,7 @@ func (x *BackupSavedSearch) GetSource() int64 {
 type PreferenceValue struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Type          string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
-	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3,oneof" json:"value,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1756,10 +1756,11 @@ const file_syncyomi_backup_v1_backup_proto_rawDesc = "" +
 	"\x05query\x18\x02 \x01(\tR\x05query\x12\x1f\n" +
 	"\vfilter_list\x18\x03 \x01(\tR\n" +
 	"filterList\x12\x16\n" +
-	"\x06source\x18\x04 \x01(\x03R\x06source\";\n" +
+	"\x06source\x18\x04 \x01(\x03R\x06source\"J\n" +
 	"\x0fPreferenceValue\x12\x12\n" +
-	"\x04type\x18\x01 \x01(\tR\x04type\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value\"_\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x19\n" +
+	"\x05value\x18\x02 \x01(\fH\x00R\x05value\x88\x01\x01B\b\n" +
+	"\x06_value\"_\n" +
 	"\x10BackupPreference\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x129\n" +
 	"\x05value\x18\x02 \x01(\v2#.syncyomi.backup.v1.PreferenceValueR\x05value\"t\n" +
@@ -1884,6 +1885,7 @@ func file_syncyomi_backup_v1_backup_proto_init() {
 	}
 	file_syncyomi_backup_v1_backup_proto_msgTypes[1].OneofWrappers = []any{}
 	file_syncyomi_backup_v1_backup_proto_msgTypes[2].OneofWrappers = []any{}
+	file_syncyomi_backup_v1_backup_proto_msgTypes[8].OneofWrappers = []any{}
 	file_syncyomi_backup_v1_backup_proto_msgTypes[11].OneofWrappers = []any{}
 	file_syncyomi_backup_v1_backup_proto_msgTypes[14].OneofWrappers = []any{}
 	file_syncyomi_backup_v1_backup_proto_msgTypes[15].OneofWrappers = []any{}

--- a/internal/database/syncstore.go
+++ b/internal/database/syncstore.go
@@ -256,6 +256,8 @@ func (t *syncStoreTx) writeItems(ctx context.Context, items []*merge.Item, seq i
 		return nil
 	}
 
+	// Postgres refuses to touch a row twice in one statement
+	items = uniqueItems(items)
 	const batch = 100
 	for start := 0; start < len(items); start += batch {
 		end := min(start+batch, len(items))
@@ -270,6 +272,25 @@ func (t *syncStoreTx) writeItems(ctx context.Context, items []*merge.Item, seq i
 		}
 	}
 	return nil
+}
+
+func uniqueItems(items []*merge.Item) []*merge.Item {
+	type id struct {
+		kind merge.Kind
+		key  string
+	}
+	seen := make(map[id]int, len(items))
+	out := make([]*merge.Item, 0, len(items))
+	for _, it := range items {
+		k := id{it.Kind, it.Key}
+		if i, ok := seen[k]; ok {
+			out[i] = it
+			continue
+		}
+		seen[k] = len(out)
+		out = append(out, it)
+	}
+	return out
 }
 
 func (t *syncStoreTx) ensureState(ctx context.Context) error {

--- a/proto/syncyomi/backup/v1/backup.proto
+++ b/proto/syncyomi/backup/v1/backup.proto
@@ -131,7 +131,7 @@ message BackupSavedSearch {
 // The value is kept opaque; the server never interprets preferences.
 message PreferenceValue {
   string type = 1;
-  bytes value = 2;
+  optional bytes value = 2;
 }
 
 message BackupPreference {


### PR DESCRIPTION
Backups can carry the same chapter url or category twice, which made Postgres reject the multi-row upsert with "ON CONFLICT DO UPDATE command cannot affect row a second time"; one item per key is kept now, the highest version winning.