### PR TITLE
fix(web): show sync key details as tables

### DIFF
--- a/web/src/components/settings/SyncKeyDetails.test.ts
+++ b/web/src/components/settings/SyncKeyDetails.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
+import { vuetify } from "@/test/setup";
+import SyncKeyDetails from "./SyncKeyDetails.vue";
+
+const { sync } = vi.hoisted(() => ({
+  sync: {
+    status: vi.fn(),
+    devices: vi.fn(),
+    history: vi.fn(),
+    restore: vi.fn(),
+  },
+}));
+
+vi.mock("@/api/APIClient", () => ({ APIClient: { sync } }));
+
+const mountDetails = async () => {
+  const wrapper = mount(SyncKeyDetails, {
+    props: { apiKey: "key1" },
+    global: {
+      plugins: [
+        vuetify,
+        [VueQueryPlugin, { queryClient: new QueryClient() }],
+      ],
+      stubs: { ConfirmationModal: true },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+};
+
+describe("SyncKeyDetails", () => {
+  it("renders devices and history as table rows", async () => {
+    sync.status.mockResolvedValue({
+      last_synced_at: "2026-08-30T15:04:27Z",
+      last_event_at: "2026-08-30T15:04:27Z",
+      last_event: "SYNC_SUCCESS",
+      last_status: "success",
+      last_device: "Phone",
+      last_message: "",
+      data_size: 5033164,
+      data_updated_at: "2026-08-30T15:04:27Z",
+    });
+    sync.devices.mockResolvedValue([
+      {
+        id: 1,
+        device_id: "dev-a",
+        device_name: "Phone",
+        last_seen: "2026-08-30T15:04:27Z",
+        last_event: "SYNC_SUCCESS",
+        last_status: "success",
+        last_message: "",
+        protocol: "v2",
+        cursor: 12,
+        created_at: "2026-08-30T15:04:27Z",
+      },
+      {
+        id: 2,
+        device_id: "dev-b",
+        device_name: "",
+        last_seen: "2026-08-30T15:00:00Z",
+        last_event: "",
+        last_status: "",
+        last_message: "",
+        protocol: "v1",
+        cursor: 0,
+        created_at: "2026-08-30T15:00:00Z",
+      },
+    ]);
+    sync.history.mockResolvedValue([
+      { id: 10, etag: "seq=12", size: 5033164, created_at: "2026-08-30T15:04:27Z" },
+      { id: 9, etag: "seq=11", size: 5033000, created_at: "2026-08-30T15:00:00Z" },
+    ]);
+
+    const wrapper = await mountDetails();
+    const tables = wrapper.findAll("table");
+    expect(tables).toHaveLength(3);
+
+    const deviceRows = tables[1].findAll("tbody tr");
+    expect(deviceRows).toHaveLength(2);
+    expect(deviceRows[0].text()).toContain("Phone");
+    expect(deviceRows[1].text()).toContain("dev-b");
+    expect(deviceRows[1].text()).toContain("legacy");
+
+    const historyRows = tables[2].findAll("tbody tr");
+    expect(historyRows).toHaveLength(2);
+    expect(historyRows[0].text()).toContain("current");
+    expect(historyRows[0].find("button").exists()).toBe(false);
+    expect(historyRows[1].text()).toContain("4.8 MB");
+    expect(historyRows[1].find("button").text()).toContain("Restore");
+  });
+
+  it("shows empty states", async () => {
+    sync.status.mockRejectedValue(new Error("404"));
+    sync.devices.mockResolvedValue([]);
+    sync.history.mockResolvedValue([]);
+
+    const wrapper = await mountDetails();
+    expect(wrapper.text()).toContain("No sync recorded yet.");
+    expect(wrapper.text()).toContain("No devices seen yet.");
+    expect(wrapper.text()).toContain("No previous payloads kept.");
+  });
+});

--- a/web/src/components/settings/SyncKeyDetails.vue
+++ b/web/src/components/settings/SyncKeyDetails.vue
@@ -5,101 +5,124 @@
         <h4 class="mb-2">Status</h4>
         <div v-if="statusQuery.isLoading.value">Loading…</div>
         <div v-else-if="!status">No sync recorded yet.</div>
-        <v-list v-else density="compact">
-          <v-list-item>
-            <v-list-item-title>Last upload</v-list-item-title>
-            <v-list-item-subtitle>{{ fmt(status.last_synced_at) }}</v-list-item-subtitle>
-          </v-list-item>
-          <v-list-item>
-            <v-list-item-title>Last event</v-list-item-title>
-            <v-list-item-subtitle>
-              <v-chip
-                v-if="status.last_status"
-                :color="statusColor(status.last_status)"
-                size="x-small"
-                class="mr-1"
-              >
-                {{ status.last_status }}
-              </v-chip>
-              {{ status.last_event || "—" }}
-              <span v-if="status.last_device"> · {{ status.last_device }}</span>
-              <span v-if="status.last_event_at"> · {{ fmt(status.last_event_at) }}</span>
-            </v-list-item-subtitle>
-          </v-list-item>
-          <v-list-item v-if="status.last_message">
-            <v-list-item-title>Message</v-list-item-title>
-            <v-list-item-subtitle>{{ status.last_message }}</v-list-item-subtitle>
-          </v-list-item>
-          <v-list-item>
-            <v-list-item-title>Stored payload</v-list-item-title>
-            <v-list-item-subtitle>
-              {{ formatBytes(status.data_size) }}
-              <span v-if="status.data_updated_at"> · {{ fmt(status.data_updated_at) }}</span>
-            </v-list-item-subtitle>
-          </v-list-item>
-        </v-list>
+        <v-table v-else density="compact">
+          <tbody>
+            <tr>
+              <th class="text-left text-no-wrap">Last upload</th>
+              <td :title="relativeDate(status.last_synced_at)">
+                {{ simplifyDate(status.last_synced_at) }}
+              </td>
+            </tr>
+            <tr>
+              <th class="text-left text-no-wrap">Last event</th>
+              <td :title="relativeDate(status.last_event_at)">
+                <v-chip
+                  v-if="status.last_status"
+                  :color="statusColor(status.last_status)"
+                  size="x-small"
+                  class="mr-1"
+                >
+                  {{ status.last_status }}
+                </v-chip>
+                {{ status.last_event || "—" }}
+                <span v-if="status.last_device"> · {{ status.last_device }}</span>
+                <span v-if="status.last_event_at"> · {{ simplifyDate(status.last_event_at) }}</span>
+              </td>
+            </tr>
+            <tr v-if="status.last_message">
+              <th class="text-left text-no-wrap">Message</th>
+              <td>{{ status.last_message }}</td>
+            </tr>
+            <tr>
+              <th class="text-left text-no-wrap">Stored payload</th>
+              <td :title="relativeDate(status.data_updated_at)">
+                {{ formatBytes(status.data_size) }}
+                <span v-if="status.data_updated_at"> · {{ simplifyDate(status.data_updated_at) }}</span>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
       </v-col>
 
-      <v-col cols="12" md="4">
+      <v-col cols="12" md="8">
         <h4 class="mb-2">Devices</h4>
-        <div v-if="devicesQuery.isLoading.value">Loading…</div>
-        <div v-else-if="!devices.length">
-          No devices seen yet. Devices appear once they report sync events.
-        </div>
-        <v-list v-else density="compact">
-          <v-list-item v-for="device in devices" :key="device.id">
-            <v-list-item-title>
-              {{ device.device_name || device.device_id }}
-              <v-chip
-                v-if="device.last_status"
-                :color="statusColor(device.last_status)"
-                size="x-small"
-                class="ml-1"
-              >
-                {{ device.last_status }}
-              </v-chip>
-              <v-chip
-                v-if="device.protocol === 'v1'"
-                color="warning"
-                size="x-small"
-                class="ml-1"
-                title="This device uses the legacy sync protocol. Update the app to sync faster and more reliably."
-              >
-                legacy
-              </v-chip>
-            </v-list-item-title>
-            <v-list-item-subtitle>
-              Last seen {{ fmt(device.last_seen) }}
-              <span v-if="device.last_event"> · {{ device.last_event }}</span>
-            </v-list-item-subtitle>
-          </v-list-item>
-        </v-list>
+        <v-data-table
+          :headers="deviceHeaders"
+          :items="devices"
+          :loading="devicesQuery.isLoading.value"
+          :sort-by="[{ key: 'last_seen', order: 'desc' }]"
+          :items-per-page="-1"
+          item-value="id"
+          density="compact"
+          hide-default-footer
+          no-data-text="No devices seen yet. Devices appear once they report sync events."
+        >
+          <template #[`item.name`]="{ item }">
+            {{ item.device_name || item.device_id }}
+          </template>
+          <template #[`item.last_status`]="{ item }">
+            <v-chip
+              v-if="item.last_status"
+              :color="statusColor(item.last_status)"
+              size="x-small"
+            >
+              {{ item.last_status }}
+            </v-chip>
+          </template>
+          <template #[`item.protocol`]="{ item }">
+            <v-chip
+              v-if="item.protocol === 'v1'"
+              color="warning"
+              size="x-small"
+              title="This device uses the legacy sync protocol. Update the app to sync faster and more reliably."
+            >
+              legacy
+            </v-chip>
+            <span v-else>{{ item.protocol || "—" }}</span>
+          </template>
+          <template #[`item.last_event`]="{ item }">
+            {{ item.last_event || "—" }}
+          </template>
+          <template #[`item.last_seen`]="{ item }">
+            <span :title="relativeDate(item.last_seen)">{{ simplifyDate(item.last_seen) }}</span>
+          </template>
+        </v-data-table>
       </v-col>
 
-      <v-col cols="12" md="4">
+      <v-col cols="12">
         <h4 class="mb-2">History</h4>
-        <div v-if="historyQuery.isLoading.value">Loading…</div>
-        <div v-else-if="!history.length">No previous payloads kept.</div>
-        <v-list v-else density="compact">
-          <v-list-item v-for="(entry, index) in history" :key="entry.id">
-            <v-list-item-title>
-              {{ fmt(entry.created_at) }}
-              <v-chip v-if="index === 0" size="x-small" class="ml-1">current</v-chip>
-            </v-list-item-title>
-            <v-list-item-subtitle>{{ formatBytes(entry.size) }}</v-list-item-subtitle>
-            <template #append>
-              <v-btn
-                v-if="index !== 0"
-                size="small"
-                variant="text"
-                :loading="restore.isPending.value && restoringId === entry.id"
-                @click="askRestore(entry.id)"
-              >
-                Restore
-              </v-btn>
-            </template>
-          </v-list-item>
-        </v-list>
+        <v-data-table
+          :headers="historyHeaders"
+          :items="history"
+          :loading="historyQuery.isLoading.value"
+          :items-per-page="-1"
+          item-value="id"
+          density="compact"
+          hide-default-footer
+          no-data-text="No previous payloads kept."
+        >
+          <template #[`item.created_at`]="{ item }">
+            <span :title="relativeDate(item.created_at)">{{ simplifyDate(item.created_at) }}</span>
+          </template>
+          <template #[`item.size`]="{ item }">
+            {{ formatBytes(item.size) }}
+          </template>
+          <template #[`item.etag`]="{ item }">
+            <code>{{ item.etag }}</code>
+          </template>
+          <template #[`item.actions`]="{ item, index }">
+            <v-chip v-if="index === 0" size="x-small">current</v-chip>
+            <v-btn
+              v-else
+              size="small"
+              variant="text"
+              :loading="restore.isPending.value && restoringId === item.id"
+              @click="askRestore(item.id)"
+            >
+              Restore
+            </v-btn>
+          </template>
+        </v-data-table>
       </v-col>
     </v-row>
 
@@ -118,6 +141,7 @@ import { computed, ref } from "vue";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 import { APIClient } from "@/api/APIClient";
 import ConfirmationModal from "@/components/modals/DeleteConfirmationModal.vue";
+import { relativeDate, simplifyDate } from "@/utils";
 
 const props = defineProps<{ apiKey: string }>();
 const emit = defineEmits<{
@@ -178,8 +202,21 @@ const confirmedRestore = () => {
   }
 };
 
-const fmt = (value: string | null | undefined) =>
-  value ? new Date(value).toLocaleString() : "—";
+const deviceHeaders = [
+  { title: "Device", key: "name", sortable: false },
+  { title: "Status", key: "last_status" },
+  { title: "Protocol", key: "protocol" },
+  { title: "Last event", key: "last_event" },
+  { title: "Last seen", key: "last_seen" },
+  { title: "Cursor", key: "cursor", align: "end" as const },
+];
+
+const historyHeaders = [
+  { title: "Created", key: "created_at", sortable: false },
+  { title: "Size", key: "size", sortable: false },
+  { title: "ETag", key: "etag", sortable: false },
+  { title: "", key: "actions", sortable: false, align: "end" as const },
+];
 
 const formatBytes = (bytes: number) => {
   if (!bytes) return "0 B";

--- a/web/src/components/settings/SyncKeyDetails.vue
+++ b/web/src/components/settings/SyncKeyDetails.vue
@@ -2,127 +2,135 @@
   <div class="pa-4">
     <v-row>
       <v-col cols="12" md="4">
-        <h4 class="mb-2">Status</h4>
-        <div v-if="statusQuery.isLoading.value">Loading…</div>
-        <div v-else-if="!status">No sync recorded yet.</div>
-        <v-table v-else density="compact">
-          <tbody>
-            <tr>
-              <th class="text-left text-no-wrap">Last upload</th>
-              <td :title="relativeDate(status.last_synced_at)">
-                {{ simplifyDate(status.last_synced_at) }}
-              </td>
-            </tr>
-            <tr>
-              <th class="text-left text-no-wrap">Last event</th>
-              <td :title="relativeDate(status.last_event_at)">
-                <v-chip
-                  v-if="status.last_status"
-                  :color="statusColor(status.last_status)"
-                  size="x-small"
-                  class="mr-1"
-                >
-                  {{ status.last_status }}
-                </v-chip>
-                {{ status.last_event || "—" }}
-                <span v-if="status.last_device"> · {{ status.last_device }}</span>
-                <span v-if="status.last_event_at"> · {{ simplifyDate(status.last_event_at) }}</span>
-              </td>
-            </tr>
-            <tr v-if="status.last_message">
-              <th class="text-left text-no-wrap">Message</th>
-              <td>{{ status.last_message }}</td>
-            </tr>
-            <tr>
-              <th class="text-left text-no-wrap">Stored payload</th>
-              <td :title="relativeDate(status.data_updated_at)">
-                {{ formatBytes(status.data_size) }}
-                <span v-if="status.data_updated_at"> · {{ simplifyDate(status.data_updated_at) }}</span>
-              </td>
-            </tr>
-          </tbody>
-        </v-table>
+        <v-card variant="outlined" title="Status">
+          <v-card-text v-if="statusQuery.isLoading.value">Loading…</v-card-text>
+          <v-card-text v-else-if="!status">No sync recorded yet.</v-card-text>
+          <v-table v-else density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left text-no-wrap">Last upload</th>
+                <td :title="relativeDate(status.last_synced_at)">
+                  {{ simplifyDate(status.last_synced_at) }}
+                </td>
+              </tr>
+              <tr>
+                <th class="text-left text-no-wrap">Last event</th>
+                <td :class="statusTextClass(status.last_status)">
+                  {{ status.last_event || "—" }}
+                  <span v-if="status.last_device">
+                    · {{ status.last_device }}</span
+                  >
+                </td>
+              </tr>
+              <tr v-if="status.last_event_at">
+                <th class="text-left text-no-wrap">Event time</th>
+                <td :title="relativeDate(status.last_event_at)">
+                  {{ simplifyDate(status.last_event_at) }}
+                </td>
+              </tr>
+              <tr v-if="status.last_message">
+                <th class="text-left text-no-wrap">Message</th>
+                <td>{{ status.last_message }}</td>
+              </tr>
+              <tr>
+                <th class="text-left text-no-wrap">Stored payload</th>
+                <td :title="relativeDate(status.data_updated_at)">
+                  {{ formatBytes(status.data_size) }}
+                  <span v-if="status.data_updated_at">
+                    · {{ simplifyDate(status.data_updated_at) }}</span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card>
       </v-col>
 
       <v-col cols="12" md="8">
-        <h4 class="mb-2">Devices</h4>
-        <v-data-table
-          :headers="deviceHeaders"
-          :items="devices"
-          :loading="devicesQuery.isLoading.value"
-          :sort-by="[{ key: 'last_seen', order: 'desc' }]"
-          :items-per-page="-1"
-          item-value="id"
-          density="compact"
-          hide-default-footer
-          no-data-text="No devices seen yet. Devices appear once they report sync events."
-        >
-          <template #[`item.name`]="{ item }">
-            {{ item.device_name || item.device_id }}
-          </template>
-          <template #[`item.last_status`]="{ item }">
-            <v-chip
-              v-if="item.last_status"
-              :color="statusColor(item.last_status)"
-              size="x-small"
-            >
-              {{ item.last_status }}
-            </v-chip>
-          </template>
-          <template #[`item.protocol`]="{ item }">
-            <v-chip
-              v-if="item.protocol === 'v1'"
-              color="warning"
-              size="x-small"
-              title="This device uses the legacy sync protocol. Update the app to sync faster and more reliably."
-            >
-              legacy
-            </v-chip>
-            <span v-else>{{ item.protocol || "—" }}</span>
-          </template>
-          <template #[`item.last_event`]="{ item }">
-            {{ item.last_event || "—" }}
-          </template>
-          <template #[`item.last_seen`]="{ item }">
-            <span :title="relativeDate(item.last_seen)">{{ simplifyDate(item.last_seen) }}</span>
-          </template>
-        </v-data-table>
+        <v-card variant="outlined" title="Devices">
+          <v-data-table
+            :headers="deviceHeaders"
+            :items="devices"
+            :loading="devicesQuery.isLoading.value"
+            :sort-by="[{ key: 'last_seen', order: 'desc' }]"
+            :items-per-page="-1"
+            item-value="id"
+            density="compact"
+            hide-default-footer
+            no-data-text="No devices seen yet. Devices appear once they report sync events."
+          >
+            <template #[`item.name`]="{ item }">
+              {{ item.device_name || item.device_id }}
+            </template>
+            <template #[`item.last_status`]="{ item }">
+              <v-chip
+                v-if="item.last_status"
+                :color="statusColor(item.last_status)"
+                size="x-small"
+              >
+                {{ item.last_status }}
+              </v-chip>
+            </template>
+            <template #[`item.protocol`]="{ item }">
+              <v-chip
+                v-if="item.protocol === 'v1'"
+                color="warning"
+                size="x-small"
+                title="This device uses the legacy sync protocol. Update the app to sync faster and more reliably."
+              >
+                legacy
+              </v-chip>
+              <span v-else>{{ item.protocol || "—" }}</span>
+            </template>
+            <template #[`item.last_event`]="{ item }">
+              {{ item.last_event || "—" }}
+            </template>
+            <template #[`item.last_seen`]="{ item }">
+              <span :title="relativeDate(item.last_seen)">{{
+                simplifyDate(item.last_seen)
+              }}</span>
+            </template>
+          </v-data-table>
+        </v-card>
       </v-col>
 
       <v-col cols="12">
-        <h4 class="mb-2">History</h4>
-        <v-data-table
-          :headers="historyHeaders"
-          :items="history"
-          :loading="historyQuery.isLoading.value"
-          :items-per-page="-1"
-          item-value="id"
-          density="compact"
-          hide-default-footer
-          no-data-text="No previous payloads kept."
-        >
-          <template #[`item.created_at`]="{ item }">
-            <span :title="relativeDate(item.created_at)">{{ simplifyDate(item.created_at) }}</span>
-          </template>
-          <template #[`item.size`]="{ item }">
-            {{ formatBytes(item.size) }}
-          </template>
-          <template #[`item.etag`]="{ item }">
-            <code>{{ item.etag }}</code>
-          </template>
-          <template #[`item.actions`]="{ item, index }">
-            <v-chip v-if="index === 0" size="x-small">current</v-chip>
-            <v-btn
-              v-else
-              size="small"
-              variant="text"
-              :loading="restore.isPending.value && restoringId === item.id"
-              @click="askRestore(item.id)"
-            >
-              Restore
-            </v-btn>
-          </template>
-        </v-data-table>
+        <v-card variant="outlined" title="History">
+          <v-data-table
+            :headers="historyHeaders"
+            :items="history"
+            :loading="historyQuery.isLoading.value"
+            :items-per-page="-1"
+            item-value="id"
+            density="compact"
+            hide-default-footer
+            no-data-text="No previous payloads kept."
+          >
+            <template #[`item.created_at`]="{ item }">
+              <span :title="relativeDate(item.created_at)">{{
+                simplifyDate(item.created_at)
+              }}</span>
+            </template>
+            <template #[`item.size`]="{ item }">
+              {{ formatBytes(item.size) }}
+            </template>
+            <template #[`item.etag`]="{ item }">
+              <code>{{ item.etag }}</code>
+            </template>
+            <template #[`item.actions`]="{ item, index }">
+              <v-chip v-if="index === 0" size="x-small">current</v-chip>
+              <v-btn
+                v-else
+                size="small"
+                variant="text"
+                :loading="restore.isPending.value && restoringId === item.id"
+                @click="askRestore(item.id)"
+              >
+                Restore
+              </v-btn>
+            </template>
+          </v-data-table>
+        </v-card>
       </v-col>
     </v-row>
 
@@ -150,9 +158,9 @@ const emit = defineEmits<{
 }>();
 
 const queryClient = useQueryClient();
-const restoreConfirmationModal = ref<InstanceType<typeof ConfirmationModal> | null>(
-  null,
-);
+const restoreConfirmationModal = ref<InstanceType<
+  typeof ConfirmationModal
+> | null>(null);
 const restoringId = ref<number | null>(null);
 
 const statusQuery = useQuery({
@@ -221,8 +229,16 @@ const historyHeaders = [
 const formatBytes = (bytes: number) => {
   if (!bytes) return "0 B";
   const units = ["B", "KB", "MB", "GB"];
-  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
   return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+};
+
+const statusTextClass = (s: string) => {
+  const color = statusColor(s);
+  return color ? `text-${color}` : "";
 };
 
 const statusColor = (s: string) => {

--- a/web/src/utils/index.test.ts
+++ b/web/src/utils/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { baseUrl, simplifyDate } from "./index";
+import { baseUrl, relativeDate, simplifyDate } from "./index";
 
 describe("baseUrl", () => {
   afterEach(() => {
@@ -35,10 +35,28 @@ describe("simplifyDate", () => {
     expect(simplifyDate("0001-01-01T00:00:00Z")).toBe("n/a");
   });
 
+  it("returns n/a for null and undefined", () => {
+    expect(simplifyDate(null)).toBe("n/a");
+    expect(simplifyDate(undefined)).toBe("n/a");
+  });
+
   it("formats a real date", () => {
     // formatISO9075 renders in local time, so assert the shape not an exact instant.
     expect(simplifyDate("2026-07-16T10:20:30Z")).toMatch(
       /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/
     );
+  });
+});
+
+describe("relativeDate", () => {
+  it("is empty for missing dates", () => {
+    expect(relativeDate(null)).toBe("");
+    expect(relativeDate("")).toBe("");
+    expect(relativeDate("0001-01-01T00:00:00Z")).toBe("");
+  });
+
+  it("describes a past date relative to now", () => {
+    const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(relativeDate(past)).toBe("5 minutes ago");
   });
 });

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { formatISO9075 } from "date-fns";
+import { formatDistanceToNow, formatISO9075 } from "date-fns";
 
 // get baseUrl sent from server rendered index template
 export function baseUrl() {
@@ -21,12 +21,18 @@ export function sseBaseUrl() {
 }
 
 // simplify date
-export function simplifyDate(date: string) {
-  if (date === "") {
+export function simplifyDate(date: string | null | undefined) {
+  if (!date || date === "0001-01-01T00:00:00Z") {
     return "n/a";
-  } else if (date !== "0001-01-01T00:00:00Z") {
-    return formatISO9075(new Date(date));
   }
 
-  return "n/a";
+  return formatISO9075(new Date(date));
+}
+
+export function relativeDate(date: string | null | undefined) {
+  if (!date || date === "0001-01-01T00:00:00Z") {
+    return "";
+  }
+
+  return formatDistanceToNow(new Date(date), { addSuffix: true });
 }


### PR DESCRIPTION
Renders the API key details panel as tables and formats sync times in the browser's local time.