### PR TITLE
fix(db): store sync timestamps in UTC

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,6 +41,10 @@ The same view shows which devices have synced with the key, when they were last 
 
 ## Upgrade notes
 
+### 1.3.1
+
+- Sync timestamps are now stored in UTC. On Postgres, servers running with a non-UTC `TZ` used to store the local wall clock in the timezone-less `TIMESTAMP` columns, so the web UI showed times shifted by the host offset. Device and status rows correct themselves on the next sync event; older history entries keep the skewed time until they roll off `syncHistoryLimit`.
+
 ### 1.3.0
 
 - New tables `sync_state` and `sync_item`; `sync_device` gains `last_cursor` and `protocol`, `sync_data` gains `rendered_seq`. The migration runs automatically.

--- a/internal/database/sync.go
+++ b/internal/database/sync.go
@@ -110,7 +110,7 @@ func (r SyncRepo) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag st
 
 	result, err := r.db.squirrel.
 		Update("sync_data").
-		Set("updated_at", time.Now()).
+		Set("updated_at", time.Now().UTC()).
 		Set("data", data).
 		Set("data_etag", newEtag).
 		Where(sq.Eq{"user_api_key": apiKey}).
@@ -144,7 +144,7 @@ func (r SyncRepo) SetSyncDataIfMatch(ctx context.Context, apiKey string, etag st
 }
 
 func (r SyncRepo) upsertSyncData(ctx context.Context, tx *sql.Tx, apiKey string, data []byte) (*string, error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	etag := newETag()
 
 	_, err := r.db.squirrel.
@@ -174,7 +174,7 @@ func (r SyncRepo) recordHistory(ctx context.Context, tx *sql.Tx, apiKey, etag st
 	_, err := r.db.squirrel.
 		Insert("sync_data_history").
 		Columns("user_api_key", "data_etag", "size", "created_at", "data").
-		Values(apiKey, etag, len(data), time.Now(), data).
+		Values(apiKey, etag, len(data), time.Now().UTC(), data).
 		RunWith(tx).
 		ExecContext(ctx)
 	if err != nil {
@@ -242,7 +242,7 @@ func (r SyncRepo) TouchDevice(ctx context.Context, apiKey string, dev domain.Dev
 		return nil
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := r.db.handler.ExecContext(ctx, `
 		INSERT INTO sync_device (user_api_key, device_id, device_name, last_seen, last_event, last_status, last_message, created_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)

--- a/internal/database/sync_test.go
+++ b/internal/database/sync_test.go
@@ -459,3 +459,51 @@ func TestSQLiteMigrationFromPreviousVersion(t *testing.T) {
 		t.Errorf("history write after migration: %v", err)
 	}
 }
+
+// Timestamp columns have no time zone on Postgres, so anything written with a local
+// offset comes back shifted; every persisted time must be UTC regardless of the host TZ.
+func TestSyncRepo_TimestampsAreUTC(t *testing.T) {
+	origLocal := time.Local
+	time.Local = time.FixedZone("test", 10*3600)
+	t.Cleanup(func() { time.Local = origLocal })
+
+	db := newTestDB(t)
+	insertTestAPIKey(t, db, "key1")
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
+	ctx := context.Background()
+
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "dev", Name: "Phone"}, "SYNC_SUCCESS", "success", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.SetSyncData(ctx, "key1", []byte("abc")); err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(name string, ts time.Time) {
+		t.Helper()
+		if _, off := ts.Zone(); off != 0 {
+			t.Errorf("%s stored with offset %d: %v", name, off, ts)
+		}
+		if d := time.Since(ts); d < 0 || d > 5*time.Second {
+			t.Errorf("%s = %v, want about now", name, ts)
+		}
+	}
+
+	devices, err := repo.ListDevices(ctx, "key1")
+	if err != nil || len(devices) != 1 {
+		t.Fatalf("devices = %v, %v", devices, err)
+	}
+	check("device.last_seen", devices[0].LastSeen)
+
+	history, err := repo.ListHistory(ctx, "key1")
+	if err != nil || len(history) != 1 {
+		t.Fatalf("history = %v, %v", history, err)
+	}
+	check("history.created_at", history[0].CreatedAt)
+
+	st, err := repo.GetStatus(ctx, "key1")
+	if err != nil || st == nil || st.DataUpdatedAt == nil {
+		t.Fatalf("status = %v, %v", st, err)
+	}
+	check("data.updated_at", *st.DataUpdatedAt)
+}

--- a/internal/database/syncstore.go
+++ b/internal/database/syncstore.go
@@ -219,7 +219,7 @@ func (t *syncStoreTx) Apply(ctx context.Context, res *merge.Result, device strin
 	_, err := t.repo.db.squirrel.
 		Update("sync_state").
 		Set("seq", newSeq).
-		Set("updated_at", time.Now()).
+		Set("updated_at", time.Now().UTC()).
 		Where(sq.Eq{"user_api_key": t.apiKey}).
 		RunWith(t.tx).
 		ExecContext(ctx)
@@ -297,7 +297,7 @@ func (t *syncStoreTx) ensureState(ctx context.Context) error {
 	if t.exists {
 		return nil
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := t.repo.db.squirrel.
 		Insert("sync_state").
 		Columns("user_api_key", "seq", "created_at", "updated_at").
@@ -337,7 +337,7 @@ func (t *syncStoreTx) RenderCache(ctx context.Context) (*domain.RenderCache, err
 }
 
 func (t *syncStoreTx) SetRenderCache(ctx context.Context, data []byte, etag string, seq int64) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := t.repo.db.squirrel.
 		Insert("sync_data").
 		Columns("user_api_key", "created_at", "updated_at", "data", "data_etag", "rendered_seq").
@@ -381,7 +381,7 @@ func (t *syncStoreTx) SetDeviceCursor(ctx context.Context, dc domain.DeviceCurso
 	if deviceKey == "" {
 		return nil
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := t.tx.ExecContext(ctx, `
 		INSERT INTO sync_device (user_api_key, device_id, device_name, last_seen, last_cursor, protocol, created_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -75,7 +75,7 @@ func (s *service) RecordContentAccess(ctx context.Context, apiKey string, dev do
 		return
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{LastSyncedAt: &now, LastDevice: dev.Name}); err != nil {
 		s.log.Warn().Err(err).Msg("failed to record sync status")
 	}
@@ -87,7 +87,7 @@ func (s *service) ReportSyncEvent(ctx context.Context, apiKey string, event stri
 		return err
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	status := statusFromEvent(ev)
 	if err := s.repo.TouchDevice(ctx, apiKey, dev, event, status, detailMessage); err != nil {
 		s.log.Warn().Err(err).Msg("failed to record device")


### PR DESCRIPTION
Stores sync timestamps in UTC so Postgres deployments with a non-UTC TZ no longer show times shifted by the host offset.