### PR TITLE
feat(e2e): add end-to-end sync test suite

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+.tools/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,81 @@
+# SyncYomi E2E suite
+
+End-to-end tests for sync protocol v2 across real clients: two Android
+TachiyomiSY apps on headless emulators, and Suwayomi-Server, all talking to a
+real SyncYomi server booted from this repo.
+
+## Requirements
+
+- Linux with KVM (`/dev/kvm` accessible)
+- Android SDK at `~/Android/Sdk` (or `$ANDROID_SDK_ROOT`) with cmdline-tools
+- Go, JDK 17+ (Maestro), `adb` on PATH
+- A TachiyomiSY debug APK (`./gradlew :app:assembleDebug` in that repo)
+- For Suwayomi scenarios: a Suwayomi-Server shadowJar (`./gradlew :server:shadowJar`)
+
+## Setup (once)
+
+```sh
+e2e/scripts/setup-env.sh   # emulator + system image + AVDs + Maestro
+e2e/scripts/doctor.sh      # verify everything
+```
+
+## Run
+
+```sh
+e2e/scripts/run-e2e.sh                 # whole suite
+e2e/scripts/run-e2e.sh -run TestS1     # one scenario
+```
+
+Env vars:
+
+| Var | Default | Meaning |
+|---|---|---|
+| `E2E_TACHIYOMI_APK` | `~/projects/TachiyomiSY/app/build/outputs/apk/debug/app-x86_64-debug.apk` | APK under test |
+| `E2E_SUWAYOMI_JAR` | unset | Suwayomi shadowJar (Suwayomi scenarios skip without it) |
+| `E2E_KEEP` | unset | `1` leaves emulators running after the suite for debugging |
+
+## How it works
+
+- `harness/` — Go orchestration: boots the server (fresh data dir, HTTP
+  onboarding, generated API key), two AVDs (`syncE2E-a/b`, headless), installs
+  the APK, seeds sync settings by writing the app's SharedPreferences via
+  `adb run-as` (host is `http://10.0.2.2:<port>`, the emulator's alias for this
+  machine), and asserts on three oracles: the decoded `/api/sync/v2/snapshot`
+  protobuf, the pulled `tachiyomi.db`, and Suwayomi's GraphQL API.
+- Library seeding goes **through the sync protocol**: a `SyntheticClient` in the
+  harness pushes a generated fixture backup to the server via `/api/sync/v2/merge`,
+  and the device pulls it on its first sync. Divergent per-device state (for merge
+  scenarios) is staged against throwaway servers on ports 8791/8792 before the
+  devices are re-pointed at the main server. In-app backup restore is not used —
+  it crashes with SQLITE_BUSY on current builds
+  (jobobby04/TachiyomiSY#1634); `flows/restore_backup.yaml` stays around for when
+  that is fixed.
+- Sync triggers: the debug-only `SyncTriggerReceiver` broadcast
+  (`<pkg>.TRIGGER_SYNC`, debug source set of TachiyomiSY) for most scenarios;
+  S1 exercises the real "Sync now" settings UI via Maestro once per run.
+- `flows/` — the few Maestro UI flows that can't be replaced by adb.
+- `scenarios/` — the tests (`//go:build e2e`), one fresh server per test,
+  emulators booted once per run.
+- Failures dump logcat, prefs, server snapshot/devices into
+  `artifacts/<run>/<test>/`.
+
+## Scenarios
+
+| Test | What it proves |
+|---|---|
+| S1 pairing (UI) | Two devices pair with a seeded server through the real "Sync now" settings UI |
+| S2 bidirectional merge | Disjoint libraries staged on separate servers converge to the union |
+| S3 read progress | Mark-as-read via the real UI reaches the server and the other device, and re-syncs don't regress it |
+| S4 category tombstone | `X-Sync-Deleted-Categories` removes the category everywhere with no resurrection |
+| S5 conflict | Concurrent chapter-read (device) and category-move (remote, higher version) both survive |
+| S6 stale cursor | A device several generations behind converges without duplicates |
+| S7 Android⇄Suwayomi | Both directions through the server, asserted via Suwayomi GraphQL |
+| S8 soak (skipped with `-short`) | The scrubbed real-library fixture stays byte-stable across repeated syncs |
+
+v1-fallback (S9) is not covered: this server always speaks v2, so the 404-probe
+path needs an old server build — test it manually when touching the fallback code.
+
+## Ports
+
+8790 (SyncYomi server), 4568 (Suwayomi), 5554/5556 (emulators). The doctor
+warns if any are taken.

--- a/e2e/flows/assert_library_title.yaml
+++ b/e2e/flows/assert_library_title.yaml
@@ -1,0 +1,8 @@
+# Smoke-asserts one manga title is visible in the library. Pass TITLE via -e TITLE=...
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- launchApp
+- tapOn: "Library"
+- extendedWaitUntil:
+    visible: ${TITLE}
+    timeout: 15000

--- a/e2e/flows/mark_read.yaml
+++ b/e2e/flows/mark_read.yaml
@@ -1,0 +1,18 @@
+# Marks all chapters of one manga read via library selection mode.
+# Pass TITLE via -e TITLE=... The bottom-menu button needs a confirm tap.
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+- launchApp
+- tapOn: "Library"
+- longPressOn: ${TITLE}
+- tapOn: "Mark as read"
+- runFlow:
+    when:
+      visible: "Mark as read"
+    commands:
+      - tapOn: "Mark as read"

--- a/e2e/flows/restore_backup.yaml
+++ b/e2e/flows/restore_backup.yaml
@@ -1,0 +1,12 @@
+# Assumes the restore screen is already open (VIEW intent on a .tachibk fired via adb).
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+- extendedWaitUntil:
+    visible: "Restore"
+    timeout: 20000
+- tapOn: "Restore"

--- a/e2e/flows/sync_now.yaml
+++ b/e2e/flows/sync_now.yaml
@@ -1,0 +1,15 @@
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+- launchApp
+- tapOn: "More"
+- tapOn: "Settings"
+- tapOn: "Data and storage"
+- scrollUntilVisible:
+    element:
+      text: "Sync now"
+- tapOn: "Sync now"

--- a/e2e/harness/adb.go
+++ b/e2e/harness/adb.go
@@ -1,0 +1,227 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	AppPackage  = "eu.kanade.tachiyomi.sy.debug"
+	prefsFile   = AppPackage + "_preferences.xml"
+	mainAct     = AppPackage + "/eu.kanade.tachiyomi.ui.main.MainActivity"
+	deviceDBDir = "databases"
+)
+
+// SyncPrefs is everything the app needs to sync without touching the UI.
+type SyncPrefs struct {
+	Host   string
+	APIKey string
+}
+
+func prefsXML(p SyncPrefs) string {
+	return fmt.Sprintf(`<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<map>
+    <string name="sync_client_host">%s</string>
+    <string name="sync_client_api_key">%s</string>
+    <int name="sync_service" value="1" />
+    <boolean name="__APP_STATE_onboarding_complete" value="true" />
+    <boolean name="appSettings" value="false" />
+    <boolean name="extensionRepoSettings" value="false" />
+    <boolean name="sourceSettings" value="false" />
+    <boolean name="privateSettings" value="false" />
+</map>
+`, p.Host, p.APIKey)
+}
+
+// InstallApp installs (replacing) the APK on the emulator.
+func (e *Emulator) InstallApp(ctx context.Context, apkPath string) error {
+	_, err := e.Adb(ctx, "install", "-r", "-g", apkPath)
+	return err
+}
+
+// ResetApp wipes app data and seeds sync preferences; the app is left stopped.
+func (e *Emulator) ResetApp(ctx context.Context, p SyncPrefs) error {
+	if out, err := e.Adb(ctx, "shell", "pm", "clear", AppPackage); err != nil || !strings.Contains(out, "Success") {
+		return fmt.Errorf("pm clear: %v %s", err, out)
+	}
+	if err := e.WriteSyncPrefs(ctx, p); err != nil {
+		return err
+	}
+	// Notifications permission so no runtime prompt blocks UI flows on API 33+.
+	_, _ = e.Adb(ctx, "shell", "pm", "grant", AppPackage, "android.permission.POST_NOTIFICATIONS")
+	// Storage access the app would normally get during onboarding; needed to read
+	// pushed backup files from /sdcard.
+	_, _ = e.Adb(ctx, "shell", "appops", "set", AppPackage, "MANAGE_EXTERNAL_STORAGE", "allow")
+	return nil
+}
+
+// WriteSyncPrefs force-stops the app and replaces its preferences, keeping the
+// library DB — used to re-point a device at a different server mid-scenario.
+// Replacing the whole file also drops v2 cursor/probe app-state, so the next
+// sync against the new host starts from scratch, as a fresh pairing would.
+func (e *Emulator) WriteSyncPrefs(ctx context.Context, p SyncPrefs) error {
+	if err := e.ForceStopApp(ctx); err != nil {
+		return err
+	}
+	script := fmt.Sprintf(`run-as %s sh -c 'mkdir -p shared_prefs && cat > shared_prefs/%s'`, AppPackage, prefsFile)
+	if out, err := e.AdbShellStdin(ctx, prefsXML(p), script); err != nil {
+		return fmt.Errorf("write prefs: %w: %s", err, out)
+	}
+	return nil
+}
+
+// AdbShellStdin runs a shell command with the given stdin content.
+func (e *Emulator) AdbShellStdin(ctx context.Context, stdin, command string) (string, error) {
+	cmd := adbCommand(ctx, e.Serial, "shell", command)
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), err
+	}
+	return string(out), nil
+}
+
+// LaunchApp starts the main activity and waits briefly for it to settle.
+func (e *Emulator) LaunchApp(ctx context.Context) error {
+	if _, err := e.Adb(ctx, "shell", "am", "start", "-n", mainAct); err != nil {
+		return err
+	}
+	time.Sleep(3 * time.Second)
+	return nil
+}
+
+func (e *Emulator) ForceStopApp(ctx context.Context) error {
+	_, err := e.Adb(ctx, "shell", "am", "force-stop", AppPackage)
+	return err
+}
+
+// TriggerSyncBroadcast fires the debug-only sync receiver (Phase 2 app hook).
+func (e *Emulator) TriggerSyncBroadcast(ctx context.Context) error {
+	out, err := e.Adb(ctx, "shell", "am", "broadcast",
+		"-a", AppPackage+".TRIGGER_SYNC", "-p", AppPackage)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(out, "Broadcast completed") {
+		return fmt.Errorf("broadcast not delivered: %s", out)
+	}
+	return nil
+}
+
+// PushBackup copies a .tachibk fixture to the device and returns its device path.
+func (e *Emulator) PushBackup(ctx context.Context, localPath string) (string, error) {
+	remote := "/sdcard/Download/" + filepath.Base(localPath)
+	if _, err := e.Adb(ctx, "push", localPath, remote); err != nil {
+		return "", err
+	}
+	return remote, nil
+}
+
+// OpenBackupFile fires a VIEW intent so the app opens its restore screen.
+func (e *Emulator) OpenBackupFile(ctx context.Context, devicePath string) error {
+	out, err := e.Adb(ctx, "shell", "am", "start",
+		"-a", "android.intent.action.VIEW",
+		"-d", "file://"+devicePath,
+		"-t", "application/octet-stream",
+		"-n", AppPackage+"/eu.kanade.tachiyomi.ui.main.MainActivity")
+	if err != nil {
+		return err
+	}
+	if strings.Contains(out, "Error") {
+		return fmt.Errorf("view intent: %s", out)
+	}
+	return nil
+}
+
+// PullAppDB force-stops the app and pulls tachiyomi.db (+wal/shm) into destDir,
+// returning the local db path.
+func (e *Emulator) PullAppDB(ctx context.Context, destDir string) (string, error) {
+	if err := e.ForceStopApp(ctx); err != nil {
+		return "", err
+	}
+	return e.pullAppDBFiles(ctx, destDir)
+}
+
+// PullAppDBLive pulls the db files without stopping the app. The copy can be
+// mid-write and unreadable — callers must treat failures as "not yet" and retry.
+func (e *Emulator) PullAppDBLive(ctx context.Context, destDir string) (string, error) {
+	return e.pullAppDBFiles(ctx, destDir)
+}
+
+func (e *Emulator) pullAppDBFiles(ctx context.Context, destDir string) (string, error) {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return "", err
+	}
+	var dbPath string
+	for _, name := range []string{"tachiyomi.db", "tachiyomi.db-wal", "tachiyomi.db-shm"} {
+		local := filepath.Join(destDir, name)
+		cmd := adbCommand(ctx, e.Serial, "exec-out", "run-as", AppPackage, "cat", deviceDBDir+"/"+name)
+		data, err := cmd.Output()
+		if err != nil {
+			if name == "tachiyomi.db" {
+				return "", fmt.Errorf("pull %s: %w", name, err)
+			}
+			continue // wal/shm may not exist after clean close
+		}
+		if err := os.WriteFile(local, data, 0o644); err != nil {
+			return "", err
+		}
+		if name == "tachiyomi.db" {
+			dbPath = local
+		}
+	}
+	return dbPath, nil
+}
+
+// ReadSyncPrefs returns the raw preferences XML currently on the device.
+func (e *Emulator) ReadSyncPrefs(ctx context.Context) (string, error) {
+	return e.Adb(ctx, "shell", "run-as", AppPackage, "cat", "shared_prefs/"+prefsFile)
+}
+
+// LastSyncTimestamp parses __APP_STATE_last_sync_timestamp from the prefs XML (0 if absent).
+func (e *Emulator) LastSyncTimestamp(ctx context.Context) (int64, error) {
+	xml, err := e.ReadSyncPrefs(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return parseLongPref(xml, "__APP_STATE_last_sync_timestamp"), nil
+}
+
+// WaitForClientSync polls until the app's last-sync pref advances past prev
+// (its value before the trigger). The app writes this pref only once it has
+// fully applied the server response, so this — not the server-side device
+// record — is the safe point to stop or inspect the app. Compared against the
+// previous pref value rather than host wall time to sidestep clock skew.
+func (e *Emulator) WaitForClientSync(ctx context.Context, prev int64, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if ts, err := e.LastSyncTimestamp(ctx); err == nil && ts > prev {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("%s: client never recorded a sync within %s", e.AVD, timeout)
+}
+
+func parseLongPref(xml, name string) int64 {
+	marker := fmt.Sprintf(`name="%s" value="`, name)
+	i := strings.Index(xml, marker)
+	if i < 0 {
+		return 0
+	}
+	rest := xml[i+len(marker):]
+	j := strings.IndexByte(rest, '"')
+	if j < 0 {
+		return 0
+	}
+	var v int64
+	fmt.Sscanf(rest[:j], "%d", &v)
+	return v
+}

--- a/e2e/harness/artifacts.go
+++ b/e2e/harness/artifacts.go
@@ -1,0 +1,58 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// CollectOnFailure registers a cleanup that, if the test failed, dumps logcat
+// from every emulator, the client prefs, and the decoded server snapshot into
+// artifactDir/<testName>/.
+func CollectOnFailure(t *testing.T, artifactDir string, server *SyncServer, emulators ...*Emulator) {
+	t.Helper()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		dir := filepath.Join(artifactDir, SanitizeName(t.Name()))
+		_ = os.MkdirAll(dir, 0o755)
+
+		for _, e := range emulators {
+			if out, err := e.Adb(ctx, "logcat", "-d"); err == nil {
+				_ = os.WriteFile(filepath.Join(dir, "logcat-"+e.AVD+".txt"), []byte(out), 0o644)
+			}
+			if xml, err := e.ReadSyncPrefs(ctx); err == nil {
+				_ = os.WriteFile(filepath.Join(dir, "prefs-"+e.AVD+".xml"), []byte(xml), 0o644)
+			}
+		}
+		if server != nil {
+			if snap, err := server.Snapshot(ctx); err == nil {
+				if data, err := json.MarshalIndent(snap, "", "  "); err == nil {
+					_ = os.WriteFile(filepath.Join(dir, "server-snapshot.json"), data, 0o644)
+				}
+			}
+			if devices, err := server.Devices(ctx); err == nil {
+				if data, err := json.MarshalIndent(devices, "", "  "); err == nil {
+					_ = os.WriteFile(filepath.Join(dir, "server-devices.json"), data, 0o644)
+				}
+			}
+		}
+		t.Logf("failure artifacts collected in %s", dir)
+	})
+}
+
+func SanitizeName(name string) string {
+	out := []rune(name)
+	for i, r := range out {
+		if r == '/' || r == ' ' {
+			out[i] = '_'
+		}
+	}
+	return string(out)
+}

--- a/e2e/harness/assert.go
+++ b/e2e/harness/assert.go
@@ -1,0 +1,165 @@
+package harness
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/SyncYomi/SyncYomi/internal/backup"
+	"github.com/SyncYomi/SyncYomi/internal/backup/pb"
+	"github.com/SyncYomi/SyncYomi/internal/domain"
+
+	_ "modernc.org/sqlite"
+)
+
+// Snapshot fetches and decodes the server's rendered library for the test API key.
+func (s *SyncServer) Snapshot(ctx context.Context) (*pb.Backup, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.BaseURL+"/api/sync/v2/snapshot", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-API-Token", s.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("snapshot: status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return backup.Decode(data)
+}
+
+// Devices lists the devices the server has seen for the test API key.
+func (s *SyncServer) Devices(ctx context.Context) ([]domain.SyncDevice, error) {
+	var devices []domain.SyncDevice
+	err := s.AdminGet(ctx, "/api/sync/admin/"+s.APIKey+"/devices", &devices)
+	return devices, err
+}
+
+// WaitForDeviceSync polls until some device's last_seen passes since and its
+// cursor is positive — i.e. a v2 merge completed after the trigger.
+func (s *SyncServer) WaitForDeviceSync(ctx context.Context, since time.Time, timeout time.Duration) (*domain.SyncDevice, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		devices, err := s.Devices(ctx)
+		if err == nil {
+			for i := range devices {
+				d := &devices[i]
+				if d.LastSeen.After(since) && d.Cursor > 0 {
+					return d, nil
+				}
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	return nil, fmt.Errorf("no device completed a sync within %s", timeout)
+}
+
+// SnapshotTitles returns the sorted favorite manga titles in a backup.
+func SnapshotTitles(b *pb.Backup) []string {
+	var titles []string
+	for _, m := range b.BackupManga {
+		if backup.IsFavorite(m) {
+			titles = append(titles, m.Title)
+		}
+	}
+	sort.Strings(titles)
+	return titles
+}
+
+// OpenAppDB opens a pulled tachiyomi.db read-only.
+func OpenAppDB(path string) (*sql.DB, error) {
+	return sql.Open("sqlite", "file:"+path+"?mode=ro")
+}
+
+// LibraryTitles returns the sorted titles of favorited manga in a pulled app DB.
+func LibraryTitles(db *sql.DB) ([]string, error) {
+	rows, err := db.Query(`SELECT title FROM mangas WHERE favorite = 1 ORDER BY title`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var titles []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		titles = append(titles, t)
+	}
+	return titles, rows.Err()
+}
+
+// ReadChapterCount returns how many chapters of the given manga are marked read.
+func ReadChapterCount(db *sql.DB, mangaTitle string) (int, error) {
+	var n int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM chapters c
+		JOIN mangas m ON m._id = c.manga_id
+		WHERE m.title = ? AND c.read = 1`, mangaTitle).Scan(&n)
+	return n, err
+}
+
+// MangaCategoryNames returns the names of the categories a manga belongs to.
+func MangaCategoryNames(db *sql.DB, mangaTitle string) ([]string, error) {
+	rows, err := db.Query(`
+		SELECT c.name FROM categories c
+		JOIN mangas_categories mc ON mc.category_id = c._id
+		JOIN mangas m ON m._id = mc.manga_id
+		WHERE m.title = ? ORDER BY c.name`, mangaTitle)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		names = append(names, n)
+	}
+	return names, rows.Err()
+}
+
+// TableCounts returns row counts for the tables sync writes to.
+func TableCounts(db *sql.DB) (mangas, chapters, categories int, err error) {
+	if err = db.QueryRow(`SELECT COUNT(*) FROM mangas`).Scan(&mangas); err != nil {
+		return
+	}
+	if err = db.QueryRow(`SELECT COUNT(*) FROM chapters`).Scan(&chapters); err != nil {
+		return
+	}
+	err = db.QueryRow(`SELECT COUNT(*) FROM categories`).Scan(&categories)
+	return
+}
+
+// CategoryNames returns user categories (excluding the built-in default).
+func CategoryNames(db *sql.DB) ([]string, error) {
+	rows, err := db.Query(`SELECT name FROM categories ORDER BY sort`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		names = append(names, n)
+	}
+	return names, rows.Err()
+}

--- a/e2e/harness/cmd/seed/main.go
+++ b/e2e/harness/cmd/seed/main.go
@@ -1,0 +1,35 @@
+// Command seed pushes a generated fixture backup to a running SyncYomi server
+// via the v2 merge endpoint, acting as a synthetic device. For manual testing.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/SyncYomi/SyncYomi/e2e/harness"
+)
+
+func main() {
+	server := flag.String("server", "http://127.0.0.1:8790", "SyncYomi base URL")
+	key := flag.String("key", "", "API key")
+	prefix := flag.String("prefix", "E2E Alpha", "fixture title prefix")
+	manga := flag.Int("manga", 5, "manga count")
+	chapters := flag.Int("chapters", 3, "chapters per manga")
+	flag.Parse()
+	if *key == "" {
+		fmt.Fprintln(os.Stderr, "-key required")
+		os.Exit(1)
+	}
+
+	srv := &harness.SyncServer{BaseURL: *server, APIKey: *key}
+	c := harness.NewSyntheticClient(srv, "e2e-seed")
+	resp, err := c.Merge(context.Background(),
+		harness.FixtureBackup(*prefix, *manga, *chapters), harness.MergeOptions{Full: true})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "merge:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("seeded; server cursor=%d, response manga=%d\n", c.Cursor, len(resp.BackupManga))
+}

--- a/e2e/harness/emulator.go
+++ b/e2e/harness/emulator.go
@@ -1,0 +1,132 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const bootTimeout = 180 * time.Second
+
+// Emulator is one headless AVD instance addressed by its adb serial.
+type Emulator struct {
+	AVD    string
+	Serial string
+	Port   int
+
+	cmd     *exec.Cmd
+	logFile *os.File
+}
+
+func sdkRoot() string {
+	if v := os.Getenv("ANDROID_SDK_ROOT"); v != "" {
+		return v
+	}
+	if v := os.Getenv("ANDROID_HOME"); v != "" {
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Android", "Sdk")
+}
+
+// StartEmulator boots an AVD headless and waits for full boot. wipeData forces a cold start.
+func StartEmulator(ctx context.Context, avd string, port int, artifactDir string, wipeData bool) (*Emulator, error) {
+	e := &Emulator{AVD: avd, Serial: fmt.Sprintf("emulator-%d", port), Port: port}
+
+	logPath := filepath.Join(artifactDir, fmt.Sprintf("emulator-%s.log", avd))
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return nil, err
+	}
+	e.logFile = logFile
+
+	args := []string{
+		"-avd", avd,
+		"-port", fmt.Sprint(port),
+		"-no-window", "-no-audio", "-no-boot-anim", "-no-snapshot",
+		"-gpu", "swiftshader_indirect",
+	}
+	if wipeData {
+		args = append(args, "-wipe-data")
+	}
+	cmd := exec.CommandContext(ctx, filepath.Join(sdkRoot(), "emulator", "emulator"), args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return nil, fmt.Errorf("start emulator %s: %w", avd, err)
+	}
+	e.cmd = cmd
+
+	if err := e.waitBooted(ctx); err != nil {
+		e.Stop()
+		if !wipeData {
+			return StartEmulator(ctx, avd, port, artifactDir, true)
+		}
+		return nil, err
+	}
+	e.settle(ctx)
+	return e, nil
+}
+
+// settle disables animations and gives the freshly booted system a moment to
+// stop churning, which avoids "System UI isn't responding" dialogs under
+// software rendering.
+func (e *Emulator) settle(ctx context.Context) {
+	for _, key := range []string{"window_animation_scale", "transition_animation_scale", "animator_duration_scale"} {
+		_, _ = e.Adb(ctx, "shell", "settings", "put", "global", key, "0")
+	}
+	time.Sleep(10 * time.Second)
+}
+
+func (e *Emulator) waitBooted(ctx context.Context) error {
+	deadline := time.Now().Add(bootTimeout)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		booted, _ := e.Adb(ctx, "shell", "getprop", "sys.boot_completed")
+		if strings.TrimSpace(booted) == "1" {
+			if out, err := e.Adb(ctx, "shell", "pm", "path", "android"); err == nil && strings.Contains(out, "package:") {
+				return nil
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("emulator %s not booted after %s", e.AVD, bootTimeout)
+}
+
+func adbCommand(ctx context.Context, serial string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "adb", append([]string{"-s", serial}, args...)...)
+}
+
+// Adb runs an adb command against this emulator and returns combined output.
+func (e *Emulator) Adb(ctx context.Context, args ...string) (string, error) {
+	out, err := adbCommand(ctx, e.Serial, args...).CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("adb %s: %w: %s", strings.Join(args, " "), err, out)
+	}
+	return string(out), nil
+}
+
+func (e *Emulator) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, _ = e.Adb(ctx, "emu", "kill")
+	if e.cmd != nil && e.cmd.Process != nil {
+		done := make(chan struct{})
+		go func() { _ = e.cmd.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			_ = e.cmd.Process.Kill()
+		}
+	}
+	if e.logFile != nil {
+		e.logFile.Close()
+	}
+}

--- a/e2e/harness/fixtures.go
+++ b/e2e/harness/fixtures.go
@@ -1,0 +1,120 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/SyncYomi/SyncYomi/internal/backup"
+	"github.com/SyncYomi/SyncYomi/internal/backup/pb"
+)
+
+// FixtureSource is a fake source id; restores work without it being installed.
+const FixtureSource int64 = 9999999999
+
+const fixtureEpochMillis int64 = 1756600000000 // fixed so generated fixtures are byte-stable
+
+// FixtureBackup builds a backup with fully known content: manga titled
+// "<prefix> 01".."<prefix> NN" with chapterCount chapters each, in one category
+// named after the prefix.
+func FixtureBackup(prefix string, mangaCount, chapterCount int) *pb.Backup {
+	category := &pb.BackupCategory{
+		Name:  prefix,
+		Order: 0,
+		Id:    1,
+		Uid:   hashUID(prefix),
+	}
+	b := &pb.Backup{
+		BackupCategories: []*pb.BackupCategory{category},
+		BackupSources: []*pb.BackupSource{
+			{Name: "E2E Fixture Source", SourceId: FixtureSource},
+		},
+	}
+	for i := 1; i <= mangaCount; i++ {
+		title := fmt.Sprintf("%s %02d", prefix, i)
+		m := &pb.BackupManga{
+			Source:      FixtureSource,
+			Url:         fmt.Sprintf("/e2e/%s/%02d", prefix, i),
+			Title:       title,
+			Status:      1,
+			DateAdded:   fixtureEpochMillis,
+			Categories:  []int64{category.Order},
+			Initialized: true,
+		}
+		backup.SetFavorite(m, true)
+		for c := 1; c <= chapterCount; c++ {
+			m.Chapters = append(m.Chapters, &pb.BackupChapter{
+				Url:           fmt.Sprintf("/e2e/%s/%02d/ch%02d", prefix, i, c),
+				Name:          fmt.Sprintf("Chapter %d", c),
+				ChapterNumber: float32(c),
+				SourceOrder:   int64(chapterCount - c),
+				DateFetch:     fixtureEpochMillis,
+			})
+		}
+		b.BackupManga = append(b.BackupManga, m)
+	}
+	return b
+}
+
+// FixtureCategoryUID returns the uid FixtureBackup assigns to its category.
+func FixtureCategoryUID(prefix string) int64 {
+	return hashUID(prefix)
+}
+
+func hashUID(s string) int64 {
+	var h int64 = 1125899906842597
+	for _, c := range s {
+		h = 31*h + int64(c)
+	}
+	if h < 0 {
+		h = -h
+	}
+	return h
+}
+
+// FixtureTitles returns the titles FixtureBackup generates, for assertions.
+func FixtureTitles(prefix string, mangaCount int) []string {
+	titles := make([]string, 0, mangaCount)
+	for i := 1; i <= mangaCount; i++ {
+		titles = append(titles, fmt.Sprintf("%s %02d", prefix, i))
+	}
+	return titles
+}
+
+func WriteFixture(path string, b *pb.Backup) error {
+	data, err := backup.EncodeGzip(b)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func ReadFixture(path string) (*pb.Backup, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return backup.Decode(data)
+}
+
+// MarkChaptersRead flips the first n chapters of the given manga title to read,
+// bumping versions the way a client edit would.
+func MarkChaptersRead(b *pb.Backup, title string, n int) {
+	for _, m := range b.BackupManga {
+		if m.Title != title {
+			continue
+		}
+		for i, ch := range m.Chapters {
+			if i >= n {
+				break
+			}
+			ch.Read = true
+			ch.LastPageRead = 0
+			ch.Version++
+		}
+		m.Version++
+	}
+}

--- a/e2e/harness/maestro.go
+++ b/e2e/harness/maestro.go
@@ -1,0 +1,56 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// RunFlow executes a Maestro flow YAML against this emulator, writing Maestro
+// output under artifactDir. flowEnv values are exposed to the flow as ${KEY}.
+func (e *Emulator) RunFlow(ctx context.Context, flowPath, artifactDir string, flowEnv map[string]string) error {
+	bin := maestroBin()
+	if _, err := os.Stat(bin); err != nil {
+		return fmt.Errorf("maestro not installed at %s — run e2e/scripts/setup-env.sh", bin)
+	}
+	outDir := filepath.Join(artifactDir, "maestro", filepath.Base(flowPath)+"-"+e.AVD)
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return err
+	}
+	args := []string{"--device", e.Serial, "test", flowPath, "--debug-output", outDir}
+	for k, v := range flowEnv {
+		args = append(args, "-e", k+"="+v)
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = append(os.Environ(), "MAESTRO_CLI_NO_ANALYTICS=1", "MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true")
+	out, err := cmd.CombinedOutput()
+	logPath := filepath.Join(outDir, "maestro.log")
+	_ = os.WriteFile(logPath, out, 0o644)
+	if err != nil {
+		return fmt.Errorf("maestro flow %s on %s failed (log: %s): %w", filepath.Base(flowPath), e.AVD, logPath, err)
+	}
+	return nil
+}
+
+// E2ERoot is the absolute path of the e2e/ directory, resolved from this source file.
+func E2ERoot() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(filepath.Dir(file))
+}
+
+// RepoRoot is the syncyomi repository root.
+func RepoRoot() string {
+	return filepath.Dir(E2ERoot())
+}
+
+func maestroBin() string {
+	return filepath.Join(E2ERoot(), ".tools", "maestro", "bin", "maestro")
+}
+
+// FlowPath resolves a flow YAML by name from e2e/flows.
+func FlowPath(name string) string {
+	return filepath.Join(E2ERoot(), "flows", name)
+}

--- a/e2e/harness/server.go
+++ b/e2e/harness/server.go
@@ -1,0 +1,195 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const (
+	ServerPort  = 8790
+	adminUser   = "e2e"
+	adminPass   = "e2e-password"
+	apiKeyName  = "e2e"
+	startupWait = 30 * time.Second
+)
+
+// SyncServer is a SyncYomi server booted from the repo source with a fresh data dir.
+type SyncServer struct {
+	BaseURL string
+	APIKey  string
+	DataDir string
+	LogPath string
+	Port    int
+
+	cmd     *exec.Cmd
+	logFile *os.File
+	admin   *http.Client
+}
+
+func configTOML(port int) string {
+	return fmt.Sprintf(`host = "0.0.0.0"
+port = %d
+logLevel = "DEBUG"
+sessionSecret = "e2e-session-secret"
+checkForUpdates = false
+databaseType = "sqlite"
+`, port)
+}
+
+// StartServer builds and boots the server on the given port, onboards the
+// admin user and provisions an API key.
+func StartServer(ctx context.Context, repoRoot, artifactDir string, port int) (*SyncServer, error) {
+	dataDir := filepath.Join(artifactDir, "server-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "config.toml"), []byte(configTOML(port)), 0o644); err != nil {
+		return nil, err
+	}
+
+	// A real binary (not `go run`) so Stop() kills the server itself, not a wrapper.
+	bin := filepath.Join(artifactDir, "syncyomi-e2e")
+	build := exec.CommandContext(ctx, "go", "build", "-o", bin, ".")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("build server: %w\n%s", err, out)
+	}
+
+	logPath := filepath.Join(artifactDir, "server.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, bin, "--config", dataDir)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return nil, fmt.Errorf("start server: %w", err)
+	}
+
+	jar, _ := cookiejar.New(nil)
+	s := &SyncServer{
+		BaseURL: fmt.Sprintf("http://127.0.0.1:%d", port),
+		Port:    port,
+		DataDir: dataDir,
+		LogPath: logPath,
+		cmd:     cmd,
+		logFile: logFile,
+		admin:   &http.Client{Jar: jar, Timeout: 15 * time.Second},
+	}
+	if err := s.waitReady(ctx); err != nil {
+		s.Stop()
+		return nil, err
+	}
+	if err := s.provision(ctx); err != nil {
+		s.Stop()
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *SyncServer) waitReady(ctx context.Context) error {
+	deadline := time.Now().Add(startupWait)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		resp, err := s.admin.Get(s.BaseURL + "/api/healthz/liveness")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return nil
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return fmt.Errorf("server not ready after %s (log: %s)", startupWait, s.LogPath)
+}
+
+func (s *SyncServer) provision(ctx context.Context) error {
+	creds := map[string]string{"username": adminUser, "password": adminPass}
+	if err := s.postJSON(ctx, "/api/auth/onboard", creds, nil); err != nil {
+		return fmt.Errorf("onboard: %w", err)
+	}
+	if err := s.postJSON(ctx, "/api/auth/login", creds, nil); err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+	var key struct {
+		Key string `json:"key"`
+	}
+	req := map[string]any{"name": apiKeyName, "scopes": []string{}}
+	if err := s.postJSON(ctx, "/api/keys", req, &key); err != nil {
+		return fmt.Errorf("create api key: %w", err)
+	}
+	if key.Key == "" {
+		return fmt.Errorf("create api key: empty key in response")
+	}
+	s.APIKey = key.Key
+	return nil
+}
+
+func (s *SyncServer) postJSON(ctx context.Context, path string, body any, out any) error {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.BaseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.admin.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("%s: status %d", path, resp.StatusCode)
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}
+
+// AdminGet performs a session-authenticated GET and decodes the JSON response into out.
+func (s *SyncServer) AdminGet(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.BaseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.admin.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("%s: status %d", path, resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// HostURLForEmulator is the server URL as seen from inside an emulator.
+func (s *SyncServer) HostURLForEmulator() string {
+	return fmt.Sprintf("http://10.0.2.2:%d", s.Port)
+}
+
+func (s *SyncServer) Stop() {
+	if s.cmd != nil && s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+		_ = s.cmd.Wait()
+	}
+	if s.logFile != nil {
+		s.logFile.Close()
+	}
+}

--- a/e2e/harness/suwayomi.go
+++ b/e2e/harness/suwayomi.go
@@ -1,0 +1,204 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const SuwayomiPort = 4568
+
+// Suwayomi is a headless Suwayomi-Server instance configured to sync against a
+// SyncYomi server.
+type Suwayomi struct {
+	BaseURL string
+	RootDir string
+	LogPath string
+
+	cmd     *exec.Cmd
+	logFile *os.File
+}
+
+// StartSuwayomi boots the shadowJar with a fresh root dir, sync enabled against srv.
+func StartSuwayomi(ctx context.Context, jarPath string, srv *SyncServer, artifactDir string) (*Suwayomi, error) {
+	rootDir := filepath.Join(artifactDir, "suwayomi-data")
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		return nil, err
+	}
+	logPath := filepath.Join(artifactDir, "suwayomi.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return nil, err
+	}
+
+	prop := func(k, v string) string { return "-Dsuwayomi.tachidesk.config.server." + k + "=" + v }
+	cmd := exec.CommandContext(ctx, "java",
+		prop("rootDir", rootDir),
+		prop("port", fmt.Sprint(SuwayomiPort)),
+		prop("systemTrayEnabled", "false"),
+		prop("initialOpenInBrowserEnabled", "false"),
+		prop("syncYomiEnabled", "true"),
+		prop("syncYomiHost", srv.BaseURL),
+		prop("syncYomiApiKey", srv.APIKey),
+		prop("syncInterval", "0s"),
+		"-jar", jarPath,
+	)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return nil, fmt.Errorf("start suwayomi: %w", err)
+	}
+	s := &Suwayomi{
+		BaseURL: fmt.Sprintf("http://127.0.0.1:%d", SuwayomiPort),
+		RootDir: rootDir,
+		LogPath: logPath,
+		cmd:     cmd,
+		logFile: logFile,
+	}
+	if err := s.waitReady(ctx); err != nil {
+		s.Stop()
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *Suwayomi) waitReady(ctx context.Context) error {
+	deadline := time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		var out struct {
+			Data struct {
+				AboutServer struct {
+					Version string `json:"version"`
+				} `json:"aboutServer"`
+			} `json:"data"`
+		}
+		if err := s.GraphQL(ctx, `{ aboutServer { version } }`, nil, &out); err == nil && out.Data.AboutServer.Version != "" {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("suwayomi not ready (log: %s)", s.LogPath)
+}
+
+// GraphQL posts a query; out receives the full {data,errors} envelope.
+func (s *Suwayomi) GraphQL(ctx context.Context, query string, variables map[string]any, out any) error {
+	payload, err := json.Marshal(map[string]any{"query": query, "variables": variables})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.BaseURL+"/api/graphql", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("graphql: status %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// StartSync triggers a sync and returns the mutation result string.
+func (s *Suwayomi) StartSync(ctx context.Context) (string, error) {
+	var out struct {
+		Data struct {
+			StartSync struct {
+				Result string `json:"result"`
+			} `json:"startSync"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	err := s.GraphQL(ctx, `mutation { startSync(input: {}) { result } }`, nil, &out)
+	if err != nil {
+		return "", err
+	}
+	if len(out.Errors) > 0 {
+		return "", fmt.Errorf("startSync: %s", out.Errors[0].Message)
+	}
+	return out.Data.StartSync.Result, nil
+}
+
+// WaitForSyncSuccess polls lastSyncStatus until SUCCESS (or ERROR/timeout).
+func (s *Suwayomi) WaitForSyncSuccess(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var out struct {
+			Data struct {
+				LastSyncStatus *struct {
+					State        string  `json:"state"`
+					ErrorMessage *string `json:"errorMessage"`
+				} `json:"lastSyncStatus"`
+			} `json:"data"`
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		if err := s.GraphQL(ctx, `{ lastSyncStatus { state errorMessage } }`, nil, &out); err == nil {
+			if len(out.Errors) > 0 {
+				return fmt.Errorf("lastSyncStatus query: %s", out.Errors[0].Message)
+			}
+			if st := out.Data.LastSyncStatus; st != nil {
+				switch st.State {
+				case "SUCCESS":
+					return nil
+				case "ERROR":
+					msg := ""
+					if st.ErrorMessage != nil {
+						msg = *st.ErrorMessage
+					}
+					return fmt.Errorf("suwayomi sync failed: %s", msg)
+				}
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("suwayomi sync not successful within %s", timeout)
+}
+
+// LibraryTitles returns the titles of manga in the Suwayomi library.
+func (s *Suwayomi) LibraryTitles(ctx context.Context) ([]string, error) {
+	var out struct {
+		Data struct {
+			Mangas struct {
+				Nodes []struct {
+					Title string `json:"title"`
+				} `json:"nodes"`
+			} `json:"mangas"`
+		} `json:"data"`
+	}
+	err := s.GraphQL(ctx, `{ mangas(condition: {inLibrary: true}) { nodes { title } } }`, nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	titles := make([]string, 0, len(out.Data.Mangas.Nodes))
+	for _, n := range out.Data.Mangas.Nodes {
+		titles = append(titles, n.Title)
+	}
+	return titles, nil
+}
+
+func (s *Suwayomi) Stop() {
+	if s.cmd != nil && s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+		_ = s.cmd.Wait()
+	}
+	if s.logFile != nil {
+		s.logFile.Close()
+	}
+}

--- a/e2e/harness/synthetic.go
+++ b/e2e/harness/synthetic.go
@@ -1,0 +1,88 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/SyncYomi/SyncYomi/internal/backup"
+	"github.com/SyncYomi/SyncYomi/internal/backup/pb"
+)
+
+// SyntheticClient speaks SyncYomi v2 directly, acting as an extra "device" so
+// tests can seed server state or inject precise conflict/cursor situations
+// without an emulator round-trip.
+type SyntheticClient struct {
+	Server     *SyncServer
+	DeviceID   string
+	DeviceName string
+	Cursor     int64
+}
+
+func NewSyntheticClient(s *SyncServer, deviceID string) *SyntheticClient {
+	return &SyntheticClient{Server: s, DeviceID: deviceID, DeviceName: "e2e-synthetic"}
+}
+
+type MergeOptions struct {
+	Full              bool
+	DeletedCategories []int64
+}
+
+// Merge posts a backup (nil = "nothing changed") and returns what the server
+// says this device lacks. The client's cursor advances from the response.
+func (c *SyntheticClient) Merge(ctx context.Context, b *pb.Backup, opts MergeOptions) (*pb.Backup, error) {
+	var body []byte
+	if b != nil {
+		var err error
+		if body, err = backup.Encode(b); err != nil {
+			return nil, err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.Server.BaseURL+"/api/sync/v2/merge", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("X-API-Token", c.Server.APIKey)
+	req.Header.Set("X-Device-ID", c.DeviceID)
+	req.Header.Set("X-Device-Name", c.DeviceName)
+	req.Header.Set("X-Sync-Cursor", strconv.FormatInt(c.Cursor, 10))
+	if opts.Full {
+		req.Header.Set("X-Sync-Full", "true")
+	}
+	if len(opts.DeletedCategories) > 0 {
+		uids := make([]string, len(opts.DeletedCategories))
+		for i, uid := range opts.DeletedCategories {
+			uids[i] = strconv.FormatInt(uid, 10)
+		}
+		req.Header.Set("X-Sync-Deleted-Categories", strings.Join(uids, ","))
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("merge: status %d: %s", resp.StatusCode, payload)
+	}
+	if v := resp.Header.Get("X-Sync-Cursor"); v != "" {
+		if cur, err := strconv.ParseInt(v, 10, 64); err == nil {
+			c.Cursor = cur
+		}
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return &pb.Backup{}, nil
+	}
+	return backup.Decode(data)
+}

--- a/e2e/scenarios/main_test.go
+++ b/e2e/scenarios/main_test.go
@@ -1,0 +1,157 @@
+//go:build e2e
+
+package scenarios
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/SyncYomi/SyncYomi/e2e/harness"
+)
+
+var (
+	emuA, emuB  *harness.Emulator
+	apkPath     string
+	artifactDir string
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) int {
+	apkPath = os.Getenv("E2E_TACHIYOMI_APK")
+	if apkPath == "" {
+		home, _ := os.UserHomeDir()
+		apkPath = filepath.Join(home, "projects", "TachiyomiSY",
+			"app", "build", "outputs", "apk", "debug", "app-x86_64-debug.apk")
+	}
+	if _, err := os.Stat(apkPath); err != nil {
+		fmt.Fprintf(os.Stderr, "TachiyomiSY APK not found at %s (set E2E_TACHIYOMI_APK)\n", apkPath)
+		return 1
+	}
+
+	artifactDir = filepath.Join(harness.E2ERoot(), "artifacts", time.Now().Format("20060102-150405"))
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Println("artifacts:", artifactDir)
+
+	ctx := context.Background()
+	fmt.Println("booting emulators (first boot can take a few minutes)...")
+	type bootResult struct {
+		emu *harness.Emulator
+		err error
+	}
+	chA := make(chan bootResult, 1)
+	chB := make(chan bootResult, 1)
+	go func() {
+		e, err := harness.StartEmulator(ctx, "syncE2E-a", 5554, artifactDir, false)
+		chA <- bootResult{e, err}
+	}()
+	go func() {
+		e, err := harness.StartEmulator(ctx, "syncE2E-b", 5556, artifactDir, false)
+		chB <- bootResult{e, err}
+	}()
+	ra, rb := <-chA, <-chB
+	emuA, emuB = ra.emu, rb.emu
+	keep := os.Getenv("E2E_KEEP") == "1"
+	defer func() {
+		if keep {
+			fmt.Println("E2E_KEEP=1: leaving emulators running")
+			return
+		}
+		if emuA != nil {
+			emuA.Stop()
+		}
+		if emuB != nil {
+			emuB.Stop()
+		}
+	}()
+	if ra.err != nil || rb.err != nil {
+		fmt.Fprintf(os.Stderr, "emulator boot failed: a=%v b=%v\n", ra.err, rb.err)
+		return 1
+	}
+
+	for _, e := range []*harness.Emulator{emuA, emuB} {
+		if err := e.InstallApp(ctx, apkPath); err != nil {
+			fmt.Fprintf(os.Stderr, "install on %s: %v\n", e.AVD, err)
+			return 1
+		}
+	}
+	return m.Run()
+}
+
+// startServer boots a fresh SyncYomi server on the given port for one test and
+// registers cleanup. Multiple servers per test get distinct ports and data dirs.
+func startServer(t *testing.T, port int) *harness.SyncServer {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	dir := filepath.Join(artifactDir, harness.SanitizeName(t.Name()), fmt.Sprintf("server-%d", port))
+	srv, err := harness.StartServer(ctx, harness.RepoRoot(), dir, port)
+	if err != nil {
+		t.Fatalf("start server on %d: %v", port, err)
+	}
+	t.Cleanup(srv.Stop)
+	return srv
+}
+
+// seedServer pushes a backup into the server through the v2 protocol, acting as
+// a synthetic device. This is the library-seeding path: the app pulls it down on
+// its first sync. (In-app backup restore is unusable until jobobby04/TachiyomiSY#1634
+// is fixed — restores die with SQLITE_BUSY on current builds.)
+func seedServer(t *testing.T, ctx context.Context, srv *harness.SyncServer, prefix string) {
+	t.Helper()
+	c := harness.NewSyntheticClient(srv, "e2e-seed-"+prefix)
+	if _, err := c.Merge(ctx, harness.FixtureBackup(prefix, fixtureAManga, fixtureAChapters), harness.MergeOptions{Full: true}); err != nil {
+		t.Fatalf("seed %s: %v", prefix, err)
+	}
+}
+
+// repoint aims a device at a different server without wiping its library, so
+// locally divergent state can be built up before devices meet on one server.
+func repoint(t *testing.T, ctx context.Context, e *harness.Emulator, srv *harness.SyncServer) {
+	t.Helper()
+	err := e.WriteSyncPrefs(ctx, harness.SyncPrefs{Host: srv.HostURLForEmulator(), APIKey: srv.APIKey})
+	if err != nil {
+		t.Fatalf("repoint %s: %v", e.AVD, err)
+	}
+}
+
+// resetApp wipes app state on the emulator and seeds sync prefs for the server.
+func resetApp(t *testing.T, ctx context.Context, e *harness.Emulator, srv *harness.SyncServer) {
+	t.Helper()
+	err := e.ResetApp(ctx, harness.SyncPrefs{Host: srv.HostURLForEmulator(), APIKey: srv.APIKey})
+	if err != nil {
+		t.Fatalf("reset app on %s: %v", e.AVD, err)
+	}
+}
+
+func libraryTitles(t *testing.T, ctx context.Context, e *harness.Emulator) ([]string, error) {
+	t.Helper()
+	dbPath, err := e.PullAppDB(ctx, filepath.Join(artifactDir, harness.SanitizeName(t.Name()), "db-"+e.AVD))
+	if err != nil {
+		return nil, err
+	}
+	db, err := harness.OpenAppDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	return harness.LibraryTitles(db)
+}
+
+// awaitLibrary polls the app DB (without stopping the app) until the library
+// holds want favorites. The sync's apply step runs as a separate WorkManager
+// job after SyncDataJob reports success, so server records and the last-sync
+// pref both fire before data lands — the DB itself is the only honest signal.
+func awaitLibrary(t *testing.T, ctx context.Context, e *harness.Emulator, want int) {
+	t.Helper()
+	awaitLibraryFor(t, ctx, e, want, 60*time.Second)
+}

--- a/e2e/scenarios/phase3_test.go
+++ b/e2e/scenarios/phase3_test.go
@@ -1,0 +1,354 @@
+//go:build e2e
+
+package scenarios
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/SyncYomi/SyncYomi/e2e/harness"
+	"github.com/SyncYomi/SyncYomi/internal/backup"
+	"github.com/SyncYomi/SyncYomi/internal/backup/pb"
+)
+
+// pairBoth gives A and B the seeded Alpha library on a fresh server.
+func pairBoth(t *testing.T, ctx context.Context, srv *harness.SyncServer) {
+	t.Helper()
+	seedServer(t, ctx, srv, "E2E Alpha")
+	resetApp(t, ctx, emuA, srv)
+	resetApp(t, ctx, emuB, srv)
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitLibrary(t, ctx, emuA, fixtureAManga)
+	syncViaBroadcast(t, ctx, emuB, srv)
+	awaitLibrary(t, ctx, emuB, fixtureAManga)
+}
+
+// TestS3_ReadProgressPropagation: A marks a manga read through the real UI, the
+// state reaches the server and B, and re-syncing A does not regress it.
+func TestS3_ReadProgressPropagation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA, emuB)
+	pairBoth(t, ctx, srv)
+
+	const title = "E2E Alpha 01"
+	if err := emuA.RunFlow(ctx, harness.FlowPath("mark_read.yaml"), artifactDir,
+		map[string]string{"TITLE": title}); err != nil {
+		t.Fatalf("mark_read flow: %v", err)
+	}
+	awaitReadCount(t, ctx, emuA, title, fixtureAChapters)
+
+	syncViaBroadcast(t, ctx, emuA, srv)
+	snap, err := srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshotReadCount(snap, title); got != fixtureAChapters {
+		t.Errorf("server has %d read chapters for %q, want %d", got, title, fixtureAChapters)
+	}
+
+	syncViaBroadcast(t, ctx, emuB, srv)
+	awaitReadCount(t, ctx, emuB, title, fixtureAChapters)
+
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitReadCount(t, ctx, emuA, title, fixtureAChapters)
+}
+
+// TestS4_CategoryDeletionTombstone: a deleted-category tombstone removes the
+// category on every device and it does not resurrect on later syncs.
+func TestS4_CategoryDeletionTombstone(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA, emuB)
+	pairBoth(t, ctx, srv)
+
+	c := harness.NewSyntheticClient(srv, "e2e-tombstone")
+	uid := harness.FixtureCategoryUID("E2E Alpha")
+	if _, err := c.Merge(ctx, nil, harness.MergeOptions{DeletedCategories: []int64{uid}}); err != nil {
+		t.Fatalf("tombstone merge: %v", err)
+	}
+
+	for _, e := range []*harness.Emulator{emuA, emuB} {
+		syncViaBroadcast(t, ctx, e, srv)
+		awaitCategoryGone(t, ctx, e, "E2E Alpha")
+	}
+	// The category lived only on the devices' own backups now; a re-sync must
+	// not bring it back.
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitCategoryGone(t, ctx, emuA, "E2E Alpha")
+	for _, e := range []*harness.Emulator{emuA, emuB} {
+		titles, err := libraryTitles(t, ctx, e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(titles) != fixtureAManga {
+			t.Errorf("%s lost manga with the category: %d left, want %d", e.AVD, len(titles), fixtureAManga)
+		}
+	}
+}
+
+// TestS5_ConflictBothEditsSurvive: A marks chapters read while another device
+// recategorizes the same manga with a higher version; after syncing, A holds
+// both edits and so does the server.
+func TestS5_ConflictBothEditsSurvive(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA)
+	seedServer(t, ctx, srv, "E2E Alpha")
+	resetApp(t, ctx, emuA, srv)
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitLibrary(t, ctx, emuA, fixtureAManga)
+
+	const title = "E2E Alpha 02"
+	// Local edit on A, not yet synced.
+	if err := emuA.RunFlow(ctx, harness.FlowPath("mark_read.yaml"), artifactDir,
+		map[string]string{"TITLE": title}); err != nil {
+		t.Fatalf("mark_read flow: %v", err)
+	}
+	awaitReadCount(t, ctx, emuA, title, fixtureAChapters)
+
+	// Concurrent remote edit: same manga moved to a new category, higher version.
+	remote := harness.FixtureBackup("E2E Alpha", fixtureAManga, fixtureAChapters)
+	conflictCat := &pb.BackupCategory{Name: "E2E Conflict", Order: 1, Id: 2, Uid: harness.FixtureCategoryUID("E2E Conflict")}
+	remote.BackupCategories = append(remote.BackupCategories, conflictCat)
+	var moved *pb.BackupManga
+	for _, m := range remote.BackupManga {
+		if m.Title == title {
+			moved = m
+		}
+	}
+	moved.Categories = []int64{conflictCat.Order}
+	moved.Version = 2
+	remote.BackupManga = []*pb.BackupManga{moved} // delta: just the contested manga
+	c := harness.NewSyntheticClient(srv, "e2e-conflict")
+	if _, err := c.Merge(ctx, remote, harness.MergeOptions{}); err != nil {
+		t.Fatalf("conflict merge: %v", err)
+	}
+
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitMangaInCategory(t, ctx, emuA, title, "E2E Conflict")
+	awaitReadCount(t, ctx, emuA, title, fixtureAChapters)
+
+	// One more sync so A pushes its merged state; server must hold both edits.
+	syncViaBroadcast(t, ctx, emuA, srv)
+	snap, err := srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshotReadCount(snap, title); got != fixtureAChapters {
+		t.Errorf("server read count for %q = %d, want %d (read state regressed)", title, got, fixtureAChapters)
+	}
+	if !snapshotMangaInCategory(snap, title, "E2E Conflict") {
+		t.Errorf("server lost the category move for %q", title)
+	}
+}
+
+// TestS6_StaleCursorConvergence: the server advances several generations while
+// A is away; A's next delta sync converges without duplicates.
+func TestS6_StaleCursorConvergence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA)
+	seedServer(t, ctx, srv, "E2E Alpha")
+	resetApp(t, ctx, emuA, srv)
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitLibrary(t, ctx, emuA, fixtureAManga)
+
+	for _, prefix := range []string{"E2E Gamma", "E2E Delta"} {
+		seedServer(t, ctx, srv, prefix)
+	}
+
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitLibrary(t, ctx, emuA, 3*fixtureAManga)
+	titles, err := libraryTitles(t, ctx, emuA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(titles) != 3*fixtureAManga {
+		t.Errorf("library has %d entries, want %d", len(titles), 3*fixtureAManga)
+	}
+	seen := map[string]bool{}
+	for _, title := range titles {
+		if seen[title] {
+			t.Errorf("duplicate library entry %q", title)
+		}
+		seen[title] = true
+	}
+}
+
+// TestS8_DedupeIdempotencySoak: a realistic scrubbed library syncs down, then
+// repeated syncs leave every row count and the server snapshot stable.
+func TestS8_DedupeIdempotencySoak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("soak test skipped with -short")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	fixture, err := harness.ReadFixture(filepath.Join(harness.RepoRoot(), "internal", "backup", "testdata", "backup_scrubbed.tachibk"))
+	if err != nil {
+		t.Fatalf("load scrubbed fixture: %v", err)
+	}
+	favorites := len(harness.SnapshotTitles(fixture))
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA)
+	c := harness.NewSyntheticClient(srv, "e2e-soak-seed")
+	if _, err := c.Merge(ctx, fixture, harness.MergeOptions{Full: true}); err != nil {
+		t.Fatalf("seed scrubbed fixture: %v", err)
+	}
+
+	resetApp(t, ctx, emuA, srv)
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitLibraryFor(t, ctx, emuA, favorites, 5*time.Minute)
+
+	var prevMangas, prevChapters, prevCategories int
+	var prevSnapshot []string
+	for i := 0; i < 3; i++ {
+		syncViaBroadcast(t, ctx, emuA, srv)
+		awaitLibraryFor(t, ctx, emuA, favorites, 2*time.Minute)
+
+		dbPath, err := emuA.PullAppDB(ctx, filepath.Join(artifactDir, harness.SanitizeName(t.Name()), "db-soak"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		db, err := harness.OpenAppDB(dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mangas, chapters, categories, err := harness.TableCounts(db)
+		db.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		snap, err := srv.Snapshot(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		snapTitles := harness.SnapshotTitles(snap)
+
+		if i > 0 {
+			if mangas != prevMangas || chapters != prevChapters || categories != prevCategories {
+				t.Errorf("pass %d: row counts drifted: mangas %d→%d chapters %d→%d categories %d→%d",
+					i, prevMangas, mangas, prevChapters, chapters, prevCategories, categories)
+			}
+			if !slices.Equal(snapTitles, prevSnapshot) {
+				t.Errorf("pass %d: server snapshot titles drifted (%d → %d entries)", i, len(prevSnapshot), len(snapTitles))
+			}
+		}
+		prevMangas, prevChapters, prevCategories, prevSnapshot = mangas, chapters, categories, snapTitles
+	}
+}
+
+// --- polling helpers on the live app DB ---
+
+func awaitReadCount(t *testing.T, ctx context.Context, e *harness.Emulator, title string, want int) {
+	t.Helper()
+	pollLiveDB(t, ctx, e, 60*time.Second, "read count", func(dbPath string) bool {
+		db, err := harness.OpenAppDB(dbPath)
+		if err != nil {
+			return false
+		}
+		defer db.Close()
+		n, err := harness.ReadChapterCount(db, title)
+		return err == nil && n == want
+	})
+}
+
+func awaitCategoryGone(t *testing.T, ctx context.Context, e *harness.Emulator, name string) {
+	t.Helper()
+	pollLiveDB(t, ctx, e, 60*time.Second, "category removal", func(dbPath string) bool {
+		db, err := harness.OpenAppDB(dbPath)
+		if err != nil {
+			return false
+		}
+		defer db.Close()
+		names, err := harness.CategoryNames(db)
+		return err == nil && !slices.Contains(names, name)
+	})
+}
+
+func awaitMangaInCategory(t *testing.T, ctx context.Context, e *harness.Emulator, title, category string) {
+	t.Helper()
+	pollLiveDB(t, ctx, e, 60*time.Second, "category move", func(dbPath string) bool {
+		db, err := harness.OpenAppDB(dbPath)
+		if err != nil {
+			return false
+		}
+		defer db.Close()
+		names, err := harness.MangaCategoryNames(db, title)
+		return err == nil && slices.Contains(names, category)
+	})
+}
+
+func awaitLibraryFor(t *testing.T, ctx context.Context, e *harness.Emulator, want int, timeout time.Duration) {
+	t.Helper()
+	pollLiveDB(t, ctx, e, timeout, "library size", func(dbPath string) bool {
+		db, err := harness.OpenAppDB(dbPath)
+		if err != nil {
+			return false
+		}
+		defer db.Close()
+		titles, err := harness.LibraryTitles(db)
+		return err == nil && len(titles) == want
+	})
+}
+
+func pollLiveDB(t *testing.T, ctx context.Context, e *harness.Emulator, timeout time.Duration, what string, ok func(dbPath string) bool) {
+	t.Helper()
+	dir := filepath.Join(artifactDir, harness.SanitizeName(t.Name()), "db-live-"+e.AVD)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if dbPath, err := e.PullAppDBLive(ctx, dir); err == nil && ok(dbPath) {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("%s: %s never reached expected state within %s", e.AVD, what, timeout)
+}
+
+// --- server snapshot helpers ---
+
+func snapshotReadCount(snap *pb.Backup, title string) int {
+	for _, m := range snap.BackupManga {
+		if m.Title != title || !backup.IsFavorite(m) {
+			continue
+		}
+		n := 0
+		for _, ch := range m.Chapters {
+			if ch.Read {
+				n++
+			}
+		}
+		return n
+	}
+	return -1
+}
+
+func snapshotMangaInCategory(snap *pb.Backup, title, category string) bool {
+	orderByName := map[string]int64{}
+	for _, c := range snap.BackupCategories {
+		orderByName[c.Name] = c.Order
+	}
+	want, found := orderByName[category]
+	if !found {
+		return false
+	}
+	for _, m := range snap.BackupManga {
+		if m.Title == title && backup.IsFavorite(m) {
+			return slices.Contains(m.Categories, want)
+		}
+	}
+	return false
+}

--- a/e2e/scenarios/suwayomi_test.go
+++ b/e2e/scenarios/suwayomi_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+
+package scenarios
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/SyncYomi/SyncYomi/e2e/harness"
+)
+
+// TestS7_AndroidSuwayomiBothDirections: Android app syncs its library up, the
+// Suwayomi server pulls it in, and Android picks up a Suwayomi-side sync back.
+func TestS7_AndroidSuwayomiBothDirections(t *testing.T) {
+	jar := os.Getenv("E2E_SUWAYOMI_JAR")
+	if jar == "" {
+		home, _ := os.UserHomeDir()
+		matches, _ := filepath.Glob(filepath.Join(home, "projects", "Suwayomi-Server", "server", "build", "Suwayomi-Server-*.jar"))
+		if len(matches) > 0 {
+			jar = matches[len(matches)-1]
+		}
+	}
+	if jar == "" {
+		t.Skip("E2E_SUWAYOMI_JAR not set and no jar found; skipping")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA)
+	seedServer(t, ctx, srv, "E2E Alpha")
+
+	resetApp(t, ctx, emuA, srv)
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitLibrary(t, ctx, emuA, fixtureAManga)
+
+	suwa, err := harness.StartSuwayomi(ctx, jar, srv, filepath.Join(artifactDir, harness.SanitizeName(t.Name())))
+	if err != nil {
+		t.Fatalf("start suwayomi: %v", err)
+	}
+	t.Cleanup(suwa.Stop)
+
+	if result, err := suwa.StartSync(ctx); err != nil {
+		t.Fatalf("startSync: %v", err)
+	} else if result != "SUCCESS" {
+		t.Fatalf("startSync result = %s", result)
+	}
+	if err := suwa.WaitForSyncSuccess(ctx, 2*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	want := harness.FixtureTitles("E2E Alpha", fixtureAManga)
+	got, err := suwa.LibraryTitles(ctx)
+	if err != nil {
+		t.Fatalf("suwayomi library: %v", err)
+	}
+	if !sameStringSet(got, want) {
+		t.Errorf("suwayomi library = %v, want %v", got, want)
+	}
+
+	// Reverse direction: another Suwayomi sync then an Android sync should both
+	// succeed and leave every side converged on the same library.
+	if _, err := suwa.StartSync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := suwa.WaitForSyncSuccess(ctx, 2*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	syncViaBroadcast(t, ctx, emuA, srv)
+
+	gotA, err := libraryTitles(t, ctx, emuA)
+	if err != nil {
+		t.Fatalf("read A library: %v", err)
+	}
+	if !sameStringSet(gotA, want) {
+		t.Errorf("android library after round-trip = %v, want %v", gotA, want)
+	}
+}

--- a/e2e/scenarios/two_devices_test.go
+++ b/e2e/scenarios/two_devices_test.go
@@ -1,0 +1,189 @@
+//go:build e2e
+
+package scenarios
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/SyncYomi/SyncYomi/e2e/harness"
+)
+
+const (
+	fixtureAManga    = 5
+	fixtureAChapters = 3
+
+	mainPort   = 8790
+	stagePortA = 8791
+	stagePortB = 8792
+)
+
+// TestS1_FirstSyncPairingUI: the server holds a seeded library; devices A and B
+// pair with it through the real settings UI and both end up with that library.
+func TestS1_FirstSyncPairingUI(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA, emuB)
+	seedServer(t, ctx, srv, "E2E Alpha")
+
+	resetApp(t, ctx, emuA, srv)
+	resetApp(t, ctx, emuB, srv)
+	syncViaUI(t, ctx, emuA, srv)
+	awaitLibrary(t, ctx, emuA, fixtureAManga)
+	syncViaUI(t, ctx, emuB, srv)
+	awaitLibrary(t, ctx, emuB, fixtureAManga)
+
+	wantTitles := harness.FixtureTitles("E2E Alpha", fixtureAManga)
+	for _, e := range []*harness.Emulator{emuA, emuB} {
+		got, err := libraryTitles(t, ctx, e)
+		if err != nil {
+			t.Fatalf("read %s library: %v", e.AVD, err)
+		}
+		if !reflect.DeepEqual(got, wantTitles) {
+			t.Errorf("%s library = %v, want %v", e.AVD, got, wantTitles)
+		}
+	}
+
+	snap, err := srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("server snapshot: %v", err)
+	}
+	if got := harness.SnapshotTitles(snap); !reflect.DeepEqual(got, wantTitles) {
+		t.Errorf("server snapshot titles = %v, want %v", got, wantTitles)
+	}
+
+	devices, err := srv.Devices(ctx)
+	if err != nil {
+		t.Fatalf("list devices: %v", err)
+	}
+	real := 0
+	for _, d := range devices {
+		if d.DeviceName == "e2e-synthetic" {
+			continue
+		}
+		real++
+		if d.Protocol != "v2" {
+			t.Errorf("device %s used protocol %q, want v2", d.DeviceName, d.Protocol)
+		}
+		if d.LastEvent != "SYNC_SUCCESS" {
+			t.Errorf("device %s last event %q, want SYNC_SUCCESS", d.DeviceName, d.LastEvent)
+		}
+	}
+	if real != 2 {
+		t.Errorf("server saw %d real devices, want 2", real)
+	}
+}
+
+// TestS2_BidirectionalMerge: A and B build disjoint libraries against separate
+// staging servers, then meet on one server and converge to the union.
+func TestS2_BidirectionalMerge(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	stageA := startServer(t, stagePortA)
+	stageB := startServer(t, stagePortB)
+	main := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, main, emuA, emuB)
+
+	seedServer(t, ctx, stageA, "E2E Alpha")
+	seedServer(t, ctx, stageB, "E2E Beta")
+
+	resetApp(t, ctx, emuA, stageA)
+	resetApp(t, ctx, emuB, stageB)
+	syncViaBroadcast(t, ctx, emuA, stageA)
+	awaitLibrary(t, ctx, emuA, fixtureAManga)
+	syncViaBroadcast(t, ctx, emuB, stageB)
+	awaitLibrary(t, ctx, emuB, fixtureAManga)
+
+	repoint(t, ctx, emuA, main)
+	repoint(t, ctx, emuB, main)
+	syncViaBroadcast(t, ctx, emuA, main)
+	syncViaBroadcast(t, ctx, emuB, main)
+	awaitLibrary(t, ctx, emuB, 2*fixtureAManga)
+	syncViaBroadcast(t, ctx, emuA, main)
+	awaitLibrary(t, ctx, emuA, 2*fixtureAManga)
+
+	union := append(harness.FixtureTitles("E2E Alpha", fixtureAManga),
+		harness.FixtureTitles("E2E Beta", fixtureAManga)...)
+
+	for _, e := range []*harness.Emulator{emuA, emuB} {
+		got, err := libraryTitles(t, ctx, e)
+		if err != nil {
+			t.Fatalf("read %s library: %v", e.AVD, err)
+		}
+		if !sameStringSet(got, union) {
+			t.Errorf("%s library = %v, want union %v", e.AVD, got, union)
+		}
+		if len(got) != len(union) {
+			t.Errorf("%s library has %d entries, want %d (duplicates?)", e.AVD, len(got), len(union))
+		}
+	}
+
+	snap, err := main.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("server snapshot: %v", err)
+	}
+	if got := harness.SnapshotTitles(snap); !sameStringSet(got, union) {
+		t.Errorf("server snapshot = %v, want union", got)
+	}
+}
+
+// syncViaUI drives the Sync now button, then waits for the server to record the
+// sync AND for the app to finish applying the response (the pref write is the
+// last step of a client sync — stopping the app before it lands loses data).
+func syncViaUI(t *testing.T, ctx context.Context, e *harness.Emulator, srv *harness.SyncServer) {
+	t.Helper()
+	prev, _ := e.LastSyncTimestamp(ctx)
+	start := time.Now()
+	if err := e.RunFlow(ctx, harness.FlowPath("sync_now.yaml"), artifactDir, nil); err != nil {
+		t.Fatalf("sync_now flow on %s: %v", e.AVD, err)
+	}
+	awaitSync(t, ctx, e, srv, prev, start)
+}
+
+// syncViaBroadcast triggers sync via the debug receiver (no UI).
+func syncViaBroadcast(t *testing.T, ctx context.Context, e *harness.Emulator, srv *harness.SyncServer) {
+	t.Helper()
+	if err := e.LaunchApp(ctx); err != nil {
+		t.Fatalf("launch app on %s: %v", e.AVD, err)
+	}
+	prev, _ := e.LastSyncTimestamp(ctx)
+	start := time.Now()
+	if err := e.TriggerSyncBroadcast(ctx); err != nil {
+		t.Fatalf("trigger sync on %s: %v", e.AVD, err)
+	}
+	awaitSync(t, ctx, e, srv, prev, start)
+}
+
+func awaitSync(t *testing.T, ctx context.Context, e *harness.Emulator, srv *harness.SyncServer, prevClientTS int64, start time.Time) {
+	t.Helper()
+	if _, err := srv.WaitForDeviceSync(ctx, start, 90*time.Second); err != nil {
+		t.Fatalf("sync from %s never reached the server: %v", e.AVD, err)
+	}
+	if err := e.WaitForClientSync(ctx, prevClientTS, 60*time.Second); err != nil {
+		t.Fatalf("sync on %s never finished applying: %v", e.AVD, err)
+	}
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]int, len(a))
+	for _, s := range a {
+		set[s]++
+	}
+	for _, s := range b {
+		set[s]--
+	}
+	for _, n := range set {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/e2e/scripts/doctor.sh
+++ b/e2e/scripts/doctor.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Verifies the E2E environment. Exit 0 = ready to run.
+set -uo pipefail
+
+SDK="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_DIR="$(dirname "$E2E_DIR")"
+APK="${E2E_TACHIYOMI_APK:-$HOME/projects/TachiyomiSY/app/build/outputs/apk/debug/app-universal-debug.apk}"
+JAR="${E2E_SUWAYOMI_JAR:-}"
+
+fail=0
+ok()   { printf '  \e[1;32mOK\e[0m   %s\n' "$*"; }
+bad()  { printf '  \e[1;31mFAIL\e[0m %s\n' "$*"; fail=1; }
+warn() { printf '  \e[1;33mWARN\e[0m %s\n' "$*"; }
+
+echo "SyncYomi E2E doctor"
+
+[ -r /dev/kvm ] && [ -w /dev/kvm ] && ok "/dev/kvm accessible" || bad "/dev/kvm not accessible"
+command -v adb >/dev/null && ok "adb: $(adb --version | head -1)" || bad "adb not on PATH"
+[ -x "$SDK/emulator/emulator" ] && ok "emulator: $("$SDK/emulator/emulator" -version 2>/dev/null | head -1)" || bad "emulator not installed (run setup-env.sh)"
+[ -d "$SDK/system-images/android-35/google_apis/x86_64" ] && ok "system image android-35 google_apis x86_64" || bad "system image missing (run setup-env.sh)"
+for avd in syncE2E-a syncE2E-b; do
+    [ -d "$HOME/.android/avd/$avd.avd" ] && ok "AVD $avd" || bad "AVD $avd missing (run setup-env.sh)"
+done
+[ -x "$E2E_DIR/.tools/maestro/bin/maestro" ] && ok "maestro: $("$E2E_DIR/.tools/maestro/bin/maestro" --version 2>/dev/null)" || bad "maestro missing (run setup-env.sh)"
+command -v java >/dev/null && ok "java: $(java -version 2>&1 | head -1)" || bad "java not on PATH (maestro needs 17+)"
+command -v go >/dev/null && ok "go: $(go version)" || bad "go not on PATH"
+[ -d "$REPO_DIR/web/dist" ] && ok "web/dist present (server embeddable)" || bad "web/dist missing — run: cd web && pnpm install && pnpm build"
+
+[ -f "$APK" ] && ok "TachiyomiSY APK: $APK" || warn "APK not found at $APK (set E2E_TACHIYOMI_APK or build :app:assembleDebug)"
+if [ -n "$JAR" ]; then
+    [ -f "$JAR" ] && ok "Suwayomi jar: $JAR" || warn "Suwayomi jar not found at $JAR"
+else
+    warn "E2E_SUWAYOMI_JAR not set (only needed for Suwayomi scenarios)"
+fi
+
+for port in 8790 8791 8792 4568 5554 5556; do
+    if ss -ltn "sport = :$port" 2>/dev/null | grep -q ":$port"; then
+        warn "port $port in use (suite expects it free)"
+    else
+        ok "port $port free"
+    fi
+done
+
+exit $fail

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Runs the E2E suite. Usage: run-e2e.sh [-run <pattern>] [extra go test args...]
+set -euo pipefail
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_DIR="$(dirname "$E2E_DIR")"
+
+if [ ! -d "$REPO_DIR/web/dist" ]; then
+    echo "[run-e2e] building web/dist (server embeds it)"
+    (cd "$REPO_DIR/web" && pnpm install --frozen-lockfile && pnpm build)
+fi
+
+"$E2E_DIR/scripts/doctor.sh" || { echo "[run-e2e] doctor failed"; exit 1; }
+
+exec go test -C "$REPO_DIR" -tags e2e ./e2e/scenarios/... -v -timeout 60m "$@"

--- a/e2e/scripts/setup-env.sh
+++ b/e2e/scripts/setup-env.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Idempotent environment setup for the SyncYomi E2E suite.
+# Installs the Android emulator, a system image, two AVDs, and a pinned Maestro CLI.
+set -euo pipefail
+
+SDK="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
+SDKMANAGER="$SDK/cmdline-tools/latest/bin/sdkmanager"
+AVDMANAGER="$SDK/cmdline-tools/latest/bin/avdmanager"
+SYSIMG="system-images;android-35;google_apis;x86_64"
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS_DIR="$E2E_DIR/.tools"
+MAESTRO_VERSION="2.9.0"
+
+log() { printf '\e[1;34m[setup]\e[0m %s\n' "$*"; }
+die() { printf '\e[1;31m[setup] ERROR:\e[0m %s\n' "$*" >&2; exit 1; }
+
+[ -e /dev/kvm ] || die "/dev/kvm not present; emulator acceleration unavailable"
+[ -r /dev/kvm ] && [ -w /dev/kvm ] || die "/dev/kvm not readable/writable by $USER"
+[ -x "$SDKMANAGER" ] || die "sdkmanager not found at $SDKMANAGER"
+
+log "accepting SDK licenses"
+yes | "$SDKMANAGER" --licenses >/dev/null 2>&1 || true
+
+if [ ! -x "$SDK/emulator/emulator" ]; then
+    log "installing emulator package"
+    "$SDKMANAGER" "emulator"
+else
+    log "emulator already installed"
+fi
+
+if [ ! -d "$SDK/system-images/android-35/google_apis/x86_64" ]; then
+    log "installing $SYSIMG (large download)"
+    "$SDKMANAGER" "$SYSIMG"
+else
+    log "system image already installed"
+fi
+
+create_avd() {
+    local name="$1" avd_dir="$HOME/.android/avd/$1.avd"
+    if [ -d "$avd_dir" ]; then
+        log "AVD $name already exists"
+    else
+        log "creating AVD $name"
+        echo no | "$AVDMANAGER" create avd -n "$name" -k "$SYSIMG" -d pixel_6 >/dev/null
+    fi
+    local cfg="$avd_dir/config.ini"
+    # Idempotent config pinning: drop any prior value, append ours.
+    for kv in "hw.ramSize=2048" "disk.dataPartition.size=6G" "hw.keyboard=yes" "hw.gpu.enabled=yes" "hw.gpu.mode=swiftshader_indirect"; do
+        local key="${kv%%=*}"
+        grep -v "^$key" "$cfg" > "$cfg.tmp" && mv "$cfg.tmp" "$cfg"
+        echo "$kv" >> "$cfg"
+    done
+}
+create_avd syncE2E-a
+create_avd syncE2E-b
+
+if [ ! -x "$TOOLS_DIR/maestro/bin/maestro" ]; then
+    log "installing Maestro CLI $MAESTRO_VERSION into $TOOLS_DIR"
+    mkdir -p "$TOOLS_DIR"
+    tmp="$(mktemp -d)"
+    curl -fsSL -o "$tmp/maestro.zip" \
+        "https://github.com/mobile-dev-inc/Maestro/releases/download/cli-$MAESTRO_VERSION/maestro.zip"
+    unzip -q "$tmp/maestro.zip" -d "$tmp"
+    rm -rf "$TOOLS_DIR/maestro"
+    mv "$tmp/maestro" "$TOOLS_DIR/maestro"
+    rm -rf "$tmp"
+else
+    log "Maestro already installed ($("$TOOLS_DIR/maestro/bin/maestro" --version 2>/dev/null || echo unknown))"
+fi
+
+log "done — run doctor.sh to verify"


### PR DESCRIPTION
Adds an E2E suite that tests protocol v2 against real clients: two TachiyomiSY apps on headless emulators and a headless Suwayomi-Server, covering pairing, bidirectional merge, read progress, category tombstones, conflicts, stale cursors and an idempotency soak.