### PR TITLE
feat(e2e): category, Suwayomi and cross-platform sync scenarios plus CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -123,6 +123,8 @@ jobs:
         run: |
           echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> "$GITHUB_ENV"
           echo "ANDROID_AVD_HOME=$HOME/.android/avd" >> "$GITHUB_ENV"
+          echo "$ANDROID_HOME/platform-tools" >> "$GITHUB_PATH"
+          echo "$ANDROID_HOME/emulator" >> "$GITHUB_PATH"
 
       - name: Cache emulator, system image and Maestro
         uses: actions/cache@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,8 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          repository: syncyomi/TachiyomiSY
-          ref: ${{ inputs.tachiyomi_ref || 'feat/syncyomi-v2' }}
+          # Post-upstream-merge: set repo variables E2E_TACHIYOMI_REPO/REF
+          # (e.g. jobobby04/TachiyomiSY + master) instead of editing this file
+          repository: ${{ vars.E2E_TACHIYOMI_REPO || 'syncyomi/TachiyomiSY' }}
+          ref: ${{ inputs.tachiyomi_ref || vars.E2E_TACHIYOMI_REF || 'feat/syncyomi-v2' }}
 
       - uses: actions/setup-java@v5
         with:
@@ -56,8 +58,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          repository: syncyomi/Suwayomi-Server
-          ref: ${{ inputs.suwayomi_ref || 'feat/syncyomi-v2' }}
+          # Post-upstream-merge: set repo variables E2E_SUWAYOMI_REPO/REF
+          # (e.g. Suwayomi/Suwayomi-Server + master) instead of editing this file
+          repository: ${{ vars.E2E_SUWAYOMI_REPO || 'syncyomi/Suwayomi-Server' }}
+          ref: ${{ inputs.suwayomi_ref || vars.E2E_SUWAYOMI_REF || 'feat/syncyomi-v2' }}
 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,13 +122,12 @@ jobs:
       - name: Point ANDROID_SDK_ROOT at the preinstalled SDK
         run: echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> "$GITHUB_ENV"
 
-      - name: Cache emulator, system image, AVDs and Maestro
+      - name: Cache emulator, system image and Maestro
         uses: actions/cache@v6
         with:
           path: |
             ${{ env.ANDROID_HOME }}/emulator
             ${{ env.ANDROID_HOME }}/system-images/android-35
-            ~/.android/avd
             e2e/.tools
           key: e2e-android-${{ runner.os }}-${{ hashFiles('e2e/scripts/setup-env.sh') }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,7 +120,9 @@ jobs:
           CI= pnpm run build
 
       - name: Point ANDROID_SDK_ROOT at the preinstalled SDK
-        run: echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> "$GITHUB_ENV"
+        run: |
+          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> "$GITHUB_ENV"
+          echo "ANDROID_AVD_HOME=$HOME/.android/avd" >> "$GITHUB_ENV"
 
       - name: Cache emulator, system image and Maestro
         uses: actions/cache@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,6 +101,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # Maestro and the Suwayomi jar both need a modern JRE; the runner default is older
+      - uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 25
+
       - uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,9 +68,15 @@ jobs:
         with:
           cache-read-only: false
 
+      - name: Configure build memory
+        # The Kotlin daemon's default heap sizing OOMs on 16 GB runners; the
+        # setting must live in gradle.properties (a -D flag doesn't reach it)
+        run: |
+          echo "org.gradle.jvmargs=-Xmx2g" >> gradle.properties
+          echo "kotlin.daemon.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=768m" >> gradle.properties
+
       - name: Build shadowJar
-        # The Kotlin daemon's default heap sizing OOMs on 16 GB runners
-        run: ./gradlew :server:shadowJar "-Dkotlin.daemon.jvmargs=-Xmx4g"
+        run: ./gradlew :server:shadowJar
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,156 @@
+name: e2e
+
+on:
+  schedule:
+    - cron: "0 16 * * *"
+  workflow_dispatch:
+    inputs:
+      tachiyomi_ref:
+        description: "TachiyomiSY ref to build"
+        default: "feat/syncyomi-v2"
+      suwayomi_ref:
+        description: "Suwayomi-Server ref to build"
+        default: "feat/syncyomi-v2"
+  pull_request:
+    paths:
+      - "internal/**"
+      - "proto/**"
+      - "e2e/**"
+      - "main.go"
+      - "go.mod"
+      - ".github/workflows/e2e.yml"
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: syncyomi/TachiyomiSY
+          ref: ${{ inputs.tachiyomi_ref || 'feat/syncyomi-v2' }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: false
+
+      - name: Build debug APK
+        run: ./gradlew :app:assembleDebug
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: tachiyomi-apk
+          path: app/build/outputs/apk/debug/app-x86_64-debug.apk
+          retention-days: 3
+
+  build-suwayomi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: syncyomi/Suwayomi-Server
+          ref: ${{ inputs.suwayomi_ref || 'feat/syncyomi-v2' }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 25
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: false
+
+      - name: Build shadowJar
+        run: ./gradlew :server:shadowJar
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: suwayomi-jar
+          path: server/build/Suwayomi-Server-*.jar
+          retention-days: 3
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [build-apk, build-suwayomi]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: ".node-version"
+
+      - name: Set up corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v7
+        with:
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Build web/dist
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          CI= pnpm run build
+
+      - name: Point ANDROID_SDK_ROOT at the preinstalled SDK
+        run: echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> "$GITHUB_ENV"
+
+      - name: Cache emulator, system image, AVDs and Maestro
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.ANDROID_HOME }}/emulator
+            ${{ env.ANDROID_HOME }}/system-images/android-35
+            ~/.android/avd
+            e2e/.tools
+          key: e2e-android-${{ runner.os }}-${{ hashFiles('e2e/scripts/setup-env.sh') }}
+
+      - name: Set up E2E environment
+        run: |
+          e2e/scripts/setup-env.sh
+          e2e/scripts/doctor.sh || true
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: tachiyomi-apk
+          path: /tmp/e2e-artifacts
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: suwayomi-jar
+          path: /tmp/e2e-artifacts
+
+      - name: Run E2E suite
+        env:
+          E2E_TACHIYOMI_APK: /tmp/e2e-artifacts/app-x86_64-debug.apk
+        run: |
+          export E2E_SUWAYOMI_JAR="$(ls /tmp/e2e-artifacts/Suwayomi-Server-*.jar | head -1)"
+          e2e/scripts/run-e2e.sh
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-failure-artifacts
+          path: e2e/artifacts/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,8 @@ jobs:
           cache-read-only: false
 
       - name: Build shadowJar
-        run: ./gradlew :server:shadowJar
+        # The Kotlin daemon's default heap sizing OOMs on 16 GB runners
+        run: ./gradlew :server:shadowJar "-Dkotlin.daemon.jvmargs=-Xmx4g"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -71,9 +71,30 @@ Env vars:
 | S6 stale cursor | A device several generations behind converges without duplicates |
 | S7 Android⇄Suwayomi | Both directions through the server, asserted via Suwayomi GraphQL |
 | S8 soak (skipped with `-short`) | The scrubbed real-library fixture stays byte-stable across repeated syncs |
+| S10 category rename (UI) | A rename keeps the category uid, doesn't duplicate, and reaches the other device |
+| S11 category reorder | A remote position swap lands on the device and survives its next push |
+| S12 create + assign (UI) | A category created and populated through the real UI reaches server and peer |
+| S13 device tombstone (UI) | Deleting a category on-device sends `X-Sync-Deleted-Categories`; no resurrection |
+| S14 Suwayomi core convergence | Suwayomi applies read progress, category rename/membership and tombstones, and pushes its own edits back |
+| S15 cross-platform deep sync | Android UI edits (read + category assign) reach Suwayomi; Suwayomi edits come back to Android |
+
+Device-originated *drag* reorder is a known gap: the drag handle has no
+accessibility label, so Maestro can't grip it; S11 covers reorder propagation
+from the server side instead.
 
 v1-fallback (S9) is not covered: this server always speaks v2, so the 404-probe
 path needs an old server build — test it manually when touching the fallback code.
+
+## CI
+
+`.github/workflows/e2e.yml` runs the whole suite on GitHub-hosted runners
+(KVM-accelerated emulators): nightly, on demand via *Run workflow* (with
+overridable TachiyomiSY/Suwayomi refs), and on PRs touching sync-relevant paths
+(`internal/`, `proto/`, `e2e/`). The APK and shadowJar are built in parallel
+jobs from the `feat/syncyomi-v2` fork branches with Gradle caching; the
+emulator, system image, AVDs and Maestro are cached between runs. On failure
+the run uploads `e2e/artifacts/` (logcat, Maestro screenshots, server logs) as
+a workflow artifact. Expect ~25–30 min warm, ~45 min on cold caches.
 
 ## Ports
 

--- a/e2e/flows/assert_library_title.yaml
+++ b/e2e/flows/assert_library_title.yaml
@@ -2,7 +2,10 @@
 appId: eu.kanade.tachiyomi.sy.debug
 ---
 - launchApp
+- extendedWaitUntil:
+    visible: "Library"
+    timeout: 30000
 - tapOn: "Library"
 - extendedWaitUntil:
     visible: ${TITLE}
-    timeout: 15000
+    timeout: 30000

--- a/e2e/flows/create_category.yaml
+++ b/e2e/flows/create_category.yaml
@@ -11,16 +11,19 @@ appId: eu.kanade.tachiyomi.sy.debug
     commands:
       - tapOn: "Wait"
 - launchApp
+- extendedWaitUntil:
+    visible: "More"
+    timeout: 30000
 - tapOn: "More"
 - tapOn: "Categories"
 - extendedWaitUntil:
     visible: "Edit categories"
-    timeout: 10000
+    timeout: 30000
 - tapOn:
     point: 85%,93%
 - extendedWaitUntil:
     visible: "Add category"
-    timeout: 10000
+    timeout: 30000
 - tapOn: "Name"
 - inputText: ${NAME}
 - tapOn:
@@ -33,4 +36,4 @@ appId: eu.kanade.tachiyomi.sy.debug
 - tapOn: "Categories"
 - extendedWaitUntil:
     visible: ${NAME}
-    timeout: 10000
+    timeout: 30000

--- a/e2e/flows/create_category.yaml
+++ b/e2e/flows/create_category.yaml
@@ -1,0 +1,36 @@
+# Creates a category via More -> Categories. Pass NAME via -e NAME=...
+# The Add FAB exposes no text/contentDescription to accessibility, so it is
+# tapped by position (stable on the fixed AVD geometry). Inside the dialog the
+# confirm button is also labeled "Add" — anchor it to "Cancel" so the tap can't
+# land on the FAB behind the scrim (which would dismiss the dialog).
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+- launchApp
+- tapOn: "More"
+- tapOn: "Categories"
+- extendedWaitUntil:
+    visible: "Edit categories"
+    timeout: 10000
+- tapOn:
+    point: 85%,93%
+- extendedWaitUntil:
+    visible: "Add category"
+    timeout: 10000
+- tapOn: "Name"
+- inputText: ${NAME}
+- tapOn:
+    text: "Add"
+    rightOf:
+      text: "Cancel"
+# The open screen's reactive category query doesn't refresh on insert (list
+# stays on the empty state until reopened), so verify by re-entering.
+- back
+- tapOn: "Categories"
+- extendedWaitUntil:
+    visible: ${NAME}
+    timeout: 10000

--- a/e2e/flows/delete_category.yaml
+++ b/e2e/flows/delete_category.yaml
@@ -1,0 +1,22 @@
+# Deletes the category at row INDEX (0-based, list position) via its per-row
+# "Delete" icon on More -> Categories. Pass INDEX and NAME (for the wait) via -e.
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+- launchApp
+- tapOn: "More"
+- tapOn: "Categories"
+- tapOn:
+    text: "Delete"
+    index: ${INDEX}
+- tapOn: "OK"
+# The open screen's reactive category query can miss the change; re-enter to verify.
+- back
+- tapOn: "Categories"
+- extendedWaitUntil:
+    notVisible: ${NAME}
+    timeout: 10000

--- a/e2e/flows/delete_category.yaml
+++ b/e2e/flows/delete_category.yaml
@@ -8,6 +8,9 @@ appId: eu.kanade.tachiyomi.sy.debug
     commands:
       - tapOn: "Wait"
 - launchApp
+- extendedWaitUntil:
+    visible: "More"
+    timeout: 30000
 - tapOn: "More"
 - tapOn: "Categories"
 - tapOn:
@@ -19,4 +22,4 @@ appId: eu.kanade.tachiyomi.sy.debug
 - tapOn: "Categories"
 - extendedWaitUntil:
     notVisible: ${NAME}
-    timeout: 10000
+    timeout: 30000

--- a/e2e/flows/mark_read.yaml
+++ b/e2e/flows/mark_read.yaml
@@ -8,6 +8,9 @@ appId: eu.kanade.tachiyomi.sy.debug
     commands:
       - tapOn: "Wait"
 - launchApp
+- extendedWaitUntil:
+    visible: "Library"
+    timeout: 30000
 - tapOn: "Library"
 - longPressOn: ${TITLE}
 - tapOn: "Mark as read"

--- a/e2e/flows/move_category.yaml
+++ b/e2e/flows/move_category.yaml
@@ -1,0 +1,28 @@
+# Moves one manga between categories through the library selection bottom menu:
+# checks NEW and unchecks OLD in the "Set categories" dialog.
+# Pass TITLE, NEW and OLD via -e.
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+- launchApp
+- tapOn: "Library"
+- longPressOn: ${TITLE}
+- tapOn: "Set categories"
+- extendedWaitUntil:
+    visible: ${NEW}
+    timeout: 10000
+# The library category tabs behind the dialog can carry the same names; anchor
+# the row taps below the dialog title so they hit the checkboxes.
+- tapOn:
+    text: ${NEW}
+    below:
+      text: "Set categories"
+- tapOn:
+    text: ${OLD}
+    below:
+      text: "Set categories"
+- tapOn: "OK"

--- a/e2e/flows/move_category.yaml
+++ b/e2e/flows/move_category.yaml
@@ -9,12 +9,15 @@ appId: eu.kanade.tachiyomi.sy.debug
     commands:
       - tapOn: "Wait"
 - launchApp
+- extendedWaitUntil:
+    visible: "Library"
+    timeout: 30000
 - tapOn: "Library"
 - longPressOn: ${TITLE}
 - tapOn: "Set categories"
 - extendedWaitUntil:
     visible: ${NEW}
-    timeout: 10000
+    timeout: 30000
 # The library category tabs behind the dialog can carry the same names; anchor
 # the row taps below the dialog title so they hit the checkboxes.
 - tapOn:

--- a/e2e/flows/rename_category_finish.yaml
+++ b/e2e/flows/rename_category_finish.yaml
@@ -7,4 +7,4 @@ appId: eu.kanade.tachiyomi.sy.debug
 - tapOn: "OK"
 - extendedWaitUntil:
     visible: ${NEW}
-    timeout: 10000
+    timeout: 30000

--- a/e2e/flows/rename_category_finish.yaml
+++ b/e2e/flows/rename_category_finish.yaml
@@ -1,0 +1,10 @@
+# Continues rename_category_open after the cursor was moved to the end of the
+# pre-filled name (adb KEYCODE_MOVE_END). No launchApp — the dialog is open.
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- eraseText: 60
+- inputText: ${NEW}
+- tapOn: "OK"
+- extendedWaitUntil:
+    visible: ${NEW}
+    timeout: 10000

--- a/e2e/flows/rename_category_open.yaml
+++ b/e2e/flows/rename_category_open.yaml
@@ -1,0 +1,16 @@
+# Opens the rename dialog for a category (tapping the row opens it). The test
+# then moves the cursor to the end via adb before running rename_category_finish.
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+- launchApp
+- tapOn: "More"
+- tapOn: "Categories"
+- tapOn: ${OLD}
+- extendedWaitUntil:
+    visible: "Rename category"
+    timeout: 10000

--- a/e2e/flows/rename_category_open.yaml
+++ b/e2e/flows/rename_category_open.yaml
@@ -8,9 +8,12 @@ appId: eu.kanade.tachiyomi.sy.debug
     commands:
       - tapOn: "Wait"
 - launchApp
+- extendedWaitUntil:
+    visible: "More"
+    timeout: 30000
 - tapOn: "More"
 - tapOn: "Categories"
 - tapOn: ${OLD}
 - extendedWaitUntil:
     visible: "Rename category"
-    timeout: 10000
+    timeout: 30000

--- a/e2e/flows/restore_backup.yaml
+++ b/e2e/flows/restore_backup.yaml
@@ -8,5 +8,5 @@ appId: eu.kanade.tachiyomi.sy.debug
       - tapOn: "Wait"
 - extendedWaitUntil:
     visible: "Restore"
-    timeout: 20000
+    timeout: 30000
 - tapOn: "Restore"

--- a/e2e/flows/set_categories.yaml
+++ b/e2e/flows/set_categories.yaml
@@ -8,11 +8,14 @@ appId: eu.kanade.tachiyomi.sy.debug
     commands:
       - tapOn: "Wait"
 - launchApp
+- extendedWaitUntil:
+    visible: "Library"
+    timeout: 30000
 - tapOn: "Library"
 - longPressOn: ${TITLE}
 - tapOn: "Set categories"
 - extendedWaitUntil:
     visible: ${CATEGORY}
-    timeout: 10000
+    timeout: 30000
 - tapOn: ${CATEGORY}
 - tapOn: "OK"

--- a/e2e/flows/set_categories.yaml
+++ b/e2e/flows/set_categories.yaml
@@ -1,0 +1,18 @@
+# Assigns one manga to a category through the library selection bottom menu.
+# Pass TITLE and CATEGORY via -e.
+appId: eu.kanade.tachiyomi.sy.debug
+---
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+- launchApp
+- tapOn: "Library"
+- longPressOn: ${TITLE}
+- tapOn: "Set categories"
+- extendedWaitUntil:
+    visible: ${CATEGORY}
+    timeout: 10000
+- tapOn: ${CATEGORY}
+- tapOn: "OK"

--- a/e2e/flows/sync_now.yaml
+++ b/e2e/flows/sync_now.yaml
@@ -6,6 +6,9 @@ appId: eu.kanade.tachiyomi.sy.debug
     commands:
       - tapOn: "Wait"
 - launchApp
+- extendedWaitUntil:
+    visible: "More"
+    timeout: 30000
 - tapOn: "More"
 - tapOn: "Settings"
 - tapOn: "Data and storage"

--- a/e2e/harness/adb.go
+++ b/e2e/harness/adb.go
@@ -29,6 +29,7 @@ func prefsXML(p SyncPrefs) string {
     <string name="sync_client_api_key">%s</string>
     <int name="sync_service" value="1" />
     <boolean name="__APP_STATE_onboarding_complete" value="true" />
+    <boolean name="eh_debug_toggle_enable_debug_overlay" value="false" />
     <boolean name="appSettings" value="false" />
     <boolean name="extensionRepoSettings" value="false" />
     <boolean name="sourceSettings" value="false" />

--- a/e2e/harness/assert.go
+++ b/e2e/harness/assert.go
@@ -163,3 +163,27 @@ func CategoryNames(db *sql.DB) ([]string, error) {
 	}
 	return names, rows.Err()
 }
+
+// CategorySort is one user category's position in the app DB.
+type CategorySort struct {
+	Name string
+	Sort int64
+}
+
+// CategorySorts returns user categories (system category excluded) by position.
+func CategorySorts(db *sql.DB) ([]CategorySort, error) {
+	rows, err := db.Query(`SELECT name, sort FROM categories WHERE _id != 0 ORDER BY sort`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []CategorySort
+	for rows.Next() {
+		var c CategorySort
+		if err := rows.Scan(&c.Name, &c.Sort); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}

--- a/e2e/harness/maestro.go
+++ b/e2e/harness/maestro.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // RunFlow executes a Maestro flow YAML against this emulator, writing Maestro
@@ -30,9 +31,19 @@ func (e *Emulator) RunFlow(ctx context.Context, flowPath, artifactDir string, fl
 	logPath := filepath.Join(outDir, "maestro.log")
 	_ = os.WriteFile(logPath, out, 0o644)
 	if err != nil {
+		// On resource-starved runners Maestro sometimes crashes at teardown
+		// after every step ran; a transcript with completed steps and no
+		// failed one means the flow itself succeeded.
+		if bytesContains(out, "COMPLETED") && !bytesContains(out, "FAILED") {
+			return nil
+		}
 		return fmt.Errorf("maestro flow %s on %s failed (log: %s): %w", filepath.Base(flowPath), e.AVD, logPath, err)
 	}
 	return nil
+}
+
+func bytesContains(b []byte, s string) bool {
+	return strings.Contains(string(b), s)
 }
 
 // E2ERoot is the absolute path of the e2e/ directory, resolved from this source file.

--- a/e2e/harness/maestro.go
+++ b/e2e/harness/maestro.go
@@ -25,21 +25,29 @@ func (e *Emulator) RunFlow(ctx context.Context, flowPath, artifactDir string, fl
 	for k, v := range flowEnv {
 		args = append(args, "-e", k+"="+v)
 	}
-	cmd := exec.CommandContext(ctx, bin, args...)
-	cmd.Env = append(os.Environ(), "MAESTRO_CLI_NO_ANALYTICS=1", "MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true")
-	out, err := cmd.CombinedOutput()
 	logPath := filepath.Join(outDir, "maestro.log")
-	_ = os.WriteFile(logPath, out, 0o644)
-	if err != nil {
+	for attempt := 1; ; attempt++ {
+		cmd := exec.CommandContext(ctx, bin, args...)
+		cmd.Env = append(os.Environ(), "MAESTRO_CLI_NO_ANALYTICS=1", "MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true")
+		out, err := cmd.CombinedOutput()
+		_ = os.WriteFile(logPath, out, 0o644)
+		if err == nil {
+			return nil
+		}
 		// On resource-starved runners Maestro sometimes crashes at teardown
 		// after every step ran; a transcript with completed steps and no
 		// failed one means the flow itself succeeded.
 		if bytesContains(out, "COMPLETED") && !bytesContains(out, "FAILED") {
 			return nil
 		}
+		// A crash before ANY step completed did nothing on the device, so one
+		// retry is safe; a mid-flow failure is not retried (steps may not be
+		// idempotent) and fails loudly instead.
+		if attempt == 1 && !bytesContains(out, "COMPLETED") {
+			continue
+		}
 		return fmt.Errorf("maestro flow %s on %s failed (log: %s): %w", filepath.Base(flowPath), e.AVD, logPath, err)
 	}
-	return nil
 }
 
 func bytesContains(b []byte, s string) bool {

--- a/e2e/harness/suwayomi.go
+++ b/e2e/harness/suwayomi.go
@@ -70,7 +70,7 @@ func StartSuwayomi(ctx context.Context, jarPath string, srv *SyncServer, artifac
 }
 
 func (s *Suwayomi) waitReady(ctx context.Context) error {
-	deadline := time.Now().Add(120 * time.Second)
+	deadline := time.Now().Add(240 * time.Second)
 	for time.Now().Before(deadline) {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/e2e/harness/suwayomi.go
+++ b/e2e/harness/suwayomi.go
@@ -171,26 +171,134 @@ func (s *Suwayomi) WaitForSyncSuccess(ctx context.Context, timeout time.Duration
 	return fmt.Errorf("suwayomi sync not successful within %s", timeout)
 }
 
-// LibraryTitles returns the titles of manga in the Suwayomi library.
-func (s *Suwayomi) LibraryTitles(ctx context.Context) ([]string, error) {
+// SuwayomiManga is one library entry with the relations the tests assert on.
+type SuwayomiManga struct {
+	ID         int
+	Title      string
+	Categories []string
+	ReadCount  int
+	ChapterIDs []int
+}
+
+// Library returns the Suwayomi library with categories and chapter read state.
+func (s *Suwayomi) Library(ctx context.Context) ([]SuwayomiManga, error) {
 	var out struct {
 		Data struct {
 			Mangas struct {
 				Nodes []struct {
-					Title string `json:"title"`
+					ID         int    `json:"id"`
+					Title      string `json:"title"`
+					Categories struct {
+						Nodes []struct {
+							Name string `json:"name"`
+						} `json:"nodes"`
+					} `json:"categories"`
+					Chapters struct {
+						Nodes []struct {
+							ID     int  `json:"id"`
+							IsRead bool `json:"isRead"`
+						} `json:"nodes"`
+					} `json:"chapters"`
 				} `json:"nodes"`
 			} `json:"mangas"`
 		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
 	}
-	err := s.GraphQL(ctx, `{ mangas(condition: {inLibrary: true}) { nodes { title } } }`, nil, &out)
+	query := `{ mangas(condition: {inLibrary: true}) { nodes {
+		id title
+		categories { nodes { name } }
+		chapters { nodes { id isRead } }
+	} } }`
+	if err := s.GraphQL(ctx, query, nil, &out); err != nil {
+		return nil, err
+	}
+	if len(out.Errors) > 0 {
+		return nil, fmt.Errorf("library query: %s", out.Errors[0].Message)
+	}
+	mangas := make([]SuwayomiManga, 0, len(out.Data.Mangas.Nodes))
+	for _, n := range out.Data.Mangas.Nodes {
+		m := SuwayomiManga{ID: n.ID, Title: n.Title}
+		for _, c := range n.Categories.Nodes {
+			m.Categories = append(m.Categories, c.Name)
+		}
+		for _, ch := range n.Chapters.Nodes {
+			m.ChapterIDs = append(m.ChapterIDs, ch.ID)
+			if ch.IsRead {
+				m.ReadCount++
+			}
+		}
+		mangas = append(mangas, m)
+	}
+	return mangas, nil
+}
+
+// LibraryTitles returns the titles of manga in the Suwayomi library.
+func (s *Suwayomi) LibraryTitles(ctx context.Context) ([]string, error) {
+	library, err := s.Library(ctx)
 	if err != nil {
 		return nil, err
 	}
-	titles := make([]string, 0, len(out.Data.Mangas.Nodes))
-	for _, n := range out.Data.Mangas.Nodes {
-		titles = append(titles, n.Title)
+	titles := make([]string, 0, len(library))
+	for _, m := range library {
+		titles = append(titles, m.Title)
 	}
 	return titles, nil
+}
+
+// CategoryNames returns Suwayomi's categories by position (default included).
+func (s *Suwayomi) CategoryNames(ctx context.Context) ([]string, error) {
+	var out struct {
+		Data struct {
+			Categories struct {
+				Nodes []struct {
+					Name  string `json:"name"`
+					Order int    `json:"order"`
+				} `json:"nodes"`
+			} `json:"categories"`
+		} `json:"data"`
+	}
+	if err := s.GraphQL(ctx, `{ categories(orderBy: ORDER) { nodes { name order } } }`, nil, &out); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(out.Data.Categories.Nodes))
+	for _, c := range out.Data.Categories.Nodes {
+		names = append(names, c.Name)
+	}
+	return names, nil
+}
+
+// MarkChaptersRead flips all chapters of the given manga to read via GraphQL.
+func (s *Suwayomi) MarkChaptersRead(ctx context.Context, title string) error {
+	library, err := s.Library(ctx)
+	if err != nil {
+		return err
+	}
+	var ids []int
+	for _, m := range library {
+		if m.Title == title {
+			ids = m.ChapterIDs
+		}
+	}
+	if len(ids) == 0 {
+		return fmt.Errorf("no chapters found for %q", title)
+	}
+	var out struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	err = s.GraphQL(ctx,
+		`mutation($ids: [Int!]!) { updateChapters(input: {ids: $ids, patch: {isRead: true}}) { chapters { id } } }`,
+		map[string]any{"ids": ids}, &out)
+	if err != nil {
+		return err
+	}
+	if len(out.Errors) > 0 {
+		return fmt.Errorf("updateChapters: %s", out.Errors[0].Message)
+	}
+	return nil
 }
 
 func (s *Suwayomi) Stop() {

--- a/e2e/scenarios/categories_test.go
+++ b/e2e/scenarios/categories_test.go
@@ -1,0 +1,258 @@
+//go:build e2e
+
+package scenarios
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/SyncYomi/SyncYomi/e2e/harness"
+	"github.com/SyncYomi/SyncYomi/internal/backup/pb"
+)
+
+// TestS10_CategoryRename: A renames the shared category through the real UI;
+// the server keeps the same uid under the new name (no duplicate), B converges,
+// and re-syncing A does not resurrect the old name.
+func TestS10_CategoryRename(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA, emuB)
+	pairBoth(t, ctx, srv)
+
+	renameCategory(t, ctx, emuA, "E2E Alpha", "E2E Renamed")
+	syncViaBroadcast(t, ctx, emuA, srv)
+
+	snap, err := srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userCats := snap.BackupCategories
+	if len(userCats) != 1 {
+		t.Fatalf("server has %d categories, want 1 (rename duplicated?): %v", len(userCats), categoryNames(userCats))
+	}
+	if got := userCats[0].Name; got != "E2E Renamed" {
+		t.Errorf("server category name = %q, want E2E Renamed", got)
+	}
+	if got, want := userCats[0].Uid, harness.FixtureCategoryUID("E2E Alpha"); got != want {
+		t.Errorf("rename changed the category uid: %d, want %d", got, want)
+	}
+
+	syncViaBroadcast(t, ctx, emuB, srv)
+	awaitCategoryPresent(t, ctx, emuB, "E2E Renamed")
+	awaitCategoryGone(t, ctx, emuB, "E2E Alpha")
+	awaitMangaInCategory(t, ctx, emuB, "E2E Alpha 01", "E2E Renamed")
+
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitCategoryGone(t, ctx, emuA, "E2E Alpha")
+	awaitCategoryPresent(t, ctx, emuA, "E2E Renamed")
+}
+
+// TestS11_CategoryReorder: a remote reorder (swapped positions, bumped versions)
+// lands on the device and survives the device's next push unchanged.
+func TestS11_CategoryReorder(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA)
+	seedServer(t, ctx, srv, "E2E Alpha")
+	resetApp(t, ctx, emuA, srv)
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitLibrary(t, ctx, emuA, fixtureAManga)
+
+	// Remote adds a second category, then swaps the two positions.
+	reorder := &pb.Backup{
+		BackupCategories: []*pb.BackupCategory{
+			{Name: "E2E Alpha", Order: 1, Id: 1, Uid: harness.FixtureCategoryUID("E2E Alpha"), Version: 1},
+			{Name: "E2E Zeta", Order: 0, Id: 2, Uid: harness.FixtureCategoryUID("E2E Zeta"), Version: 1},
+		},
+	}
+	c := harness.NewSyntheticClient(srv, "e2e-reorder")
+	if _, err := c.Merge(ctx, reorder, harness.MergeOptions{}); err != nil {
+		t.Fatalf("reorder merge: %v", err)
+	}
+
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitCategoryPresent(t, ctx, emuA, "E2E Zeta")
+	wantOrder := []string{"E2E Zeta", "E2E Alpha"}
+	awaitCategoryOrder(t, ctx, emuA, wantOrder)
+
+	// The device's own push must not churn the order back.
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitCategoryOrder(t, ctx, emuA, wantOrder)
+	snap, err := srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshotCategoryOrder(snap); !slices.Equal(got, wantOrder) {
+		t.Errorf("server category order = %v, want %v", got, wantOrder)
+	}
+}
+
+// TestS12_CreateAndAssignCategory: A creates a category and assigns a manga to
+// it through the real UI; server and B converge.
+func TestS12_CreateAndAssignCategory(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA, emuB)
+	pairBoth(t, ctx, srv)
+
+	createAndAssign(t, ctx, srv, "E2E Zeta", "E2E Alpha 03")
+
+	syncViaBroadcast(t, ctx, emuB, srv)
+	awaitCategoryPresent(t, ctx, emuB, "E2E Zeta")
+	awaitMangaInCategory(t, ctx, emuB, "E2E Alpha 03", "E2E Zeta")
+}
+
+// TestS13_DeviceOriginatedCategoryTombstone: A deletes its category through the
+// real UI, which must send the deleted-uid tombstone; the category disappears
+// everywhere and never resurrects, while the manga survives.
+func TestS13_DeviceOriginatedCategoryTombstone(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA, emuB)
+	pairBoth(t, ctx, srv)
+
+	createAndAssign(t, ctx, srv, "E2E Zeta", "E2E Alpha 03")
+	syncViaBroadcast(t, ctx, emuB, srv)
+	awaitCategoryPresent(t, ctx, emuB, "E2E Zeta")
+
+	// Rows sort by position: "E2E Alpha" at 0, "E2E Zeta" at 1.
+	if err := emuA.RunFlow(ctx, harness.FlowPath("delete_category.yaml"), artifactDir,
+		map[string]string{"INDEX": "1", "NAME": "E2E Zeta"}); err != nil {
+		t.Fatalf("delete flow: %v", err)
+	}
+	syncViaBroadcast(t, ctx, emuA, srv)
+
+	snap, err := srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names := categoryNames(snap.BackupCategories); slices.Contains(names, "E2E Zeta") {
+		t.Fatalf("server still has E2E Zeta after device tombstone: %v", names)
+	}
+
+	syncViaBroadcast(t, ctx, emuB, srv)
+	awaitCategoryGone(t, ctx, emuB, "E2E Zeta")
+
+	// No resurrection on further syncs, and the manga survives everywhere.
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitCategoryGone(t, ctx, emuA, "E2E Zeta")
+	syncViaBroadcast(t, ctx, emuB, srv)
+	awaitCategoryGone(t, ctx, emuB, "E2E Zeta")
+	for _, e := range []*harness.Emulator{emuA, emuB} {
+		titles, err := libraryTitles(t, ctx, e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(titles) != fixtureAManga {
+			t.Errorf("%s has %d manga after category delete, want %d", e.AVD, len(titles), fixtureAManga)
+		}
+	}
+}
+
+// renameCategory drives the rename dialog. The pre-filled field opens with the
+// cursor at position 0, so the flow is split around an adb KEYCODE_MOVE_END to
+// get the cursor behind the old name before erasing it.
+func renameCategory(t *testing.T, ctx context.Context, e *harness.Emulator, oldName, newName string) {
+	t.Helper()
+	if err := e.RunFlow(ctx, harness.FlowPath("rename_category_open.yaml"), artifactDir,
+		map[string]string{"OLD": oldName}); err != nil {
+		t.Fatalf("rename open flow: %v", err)
+	}
+	if _, err := e.Adb(ctx, "shell", "input", "keyevent", "KEYCODE_MOVE_END"); err != nil {
+		t.Fatalf("move cursor: %v", err)
+	}
+	if err := e.RunFlow(ctx, harness.FlowPath("rename_category_finish.yaml"), artifactDir,
+		map[string]string{"NEW": newName}); err != nil {
+		t.Fatalf("rename finish flow: %v", err)
+	}
+}
+
+// createAndAssign drives the create-category and set-categories UI on A and
+// syncs the result up, asserting the server holds both.
+func createAndAssign(t *testing.T, ctx context.Context, srv *harness.SyncServer, category, title string) {
+	t.Helper()
+	if err := emuA.RunFlow(ctx, harness.FlowPath("create_category.yaml"), artifactDir,
+		map[string]string{"NAME": category}); err != nil {
+		t.Fatalf("create category flow: %v", err)
+	}
+	if err := emuA.RunFlow(ctx, harness.FlowPath("set_categories.yaml"), artifactDir,
+		map[string]string{"TITLE": title, "CATEGORY": category}); err != nil {
+		t.Fatalf("set categories flow: %v", err)
+	}
+	awaitMangaInCategory(t, ctx, emuA, title, category)
+	syncViaBroadcast(t, ctx, emuA, srv)
+
+	snap, err := srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names := categoryNames(snap.BackupCategories); !slices.Contains(names, category) {
+		t.Fatalf("server categories %v missing %q after push", names, category)
+	}
+	if !snapshotMangaInCategory(snap, title, category) {
+		t.Fatalf("server does not have %q in category %q", title, category)
+	}
+}
+
+func awaitCategoryPresent(t *testing.T, ctx context.Context, e *harness.Emulator, name string) {
+	t.Helper()
+	pollLiveDB(t, ctx, e, 60*time.Second, "category "+name+" present", func(dbPath string) bool {
+		db, err := harness.OpenAppDB(dbPath)
+		if err != nil {
+			return false
+		}
+		defer db.Close()
+		names, err := harness.CategoryNames(db)
+		return err == nil && slices.Contains(names, name)
+	})
+}
+
+// awaitCategoryOrder waits until the user categories appear exactly in the
+// given position order.
+func awaitCategoryOrder(t *testing.T, ctx context.Context, e *harness.Emulator, want []string) {
+	t.Helper()
+	pollLiveDB(t, ctx, e, 60*time.Second, "category order", func(dbPath string) bool {
+		db, err := harness.OpenAppDB(dbPath)
+		if err != nil {
+			return false
+		}
+		defer db.Close()
+		sorts, err := harness.CategorySorts(db)
+		if err != nil || len(sorts) != len(want) {
+			return false
+		}
+		for i, c := range sorts {
+			if c.Name != want[i] {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func categoryNames(cats []*pb.BackupCategory) []string {
+	names := make([]string, 0, len(cats))
+	for _, c := range cats {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+// snapshotCategoryOrder returns the server's category names by ascending order value.
+func snapshotCategoryOrder(snap *pb.Backup) []string {
+	cats := slices.Clone(snap.BackupCategories)
+	slices.SortFunc(cats, func(a, b *pb.BackupCategory) int {
+		return int(a.Order - b.Order)
+	})
+	return categoryNames(cats)
+}

--- a/e2e/scenarios/phase3_test.go
+++ b/e2e/scenarios/phase3_test.go
@@ -136,6 +136,7 @@ func TestS5_ConflictBothEditsSurvive(t *testing.T) {
 
 	syncViaBroadcast(t, ctx, emuA, srv)
 	awaitMangaInCategory(t, ctx, emuA, title, "E2E Conflict")
+	awaitMangaNotInCategory(t, ctx, emuA, title, "E2E Alpha")
 	awaitReadCount(t, ctx, emuA, title, fixtureAChapters)
 
 	// One more sync so A pushes its merged state; server must hold both edits.
@@ -289,6 +290,21 @@ func awaitMangaInCategory(t *testing.T, ctx context.Context, e *harness.Emulator
 		defer db.Close()
 		names, err := harness.MangaCategoryNames(db, title)
 		return err == nil && slices.Contains(names, category)
+	})
+}
+
+// awaitMangaNotInCategory verifies a move removed the old membership — a move
+// that merely adds must fail this.
+func awaitMangaNotInCategory(t *testing.T, ctx context.Context, e *harness.Emulator, title, category string) {
+	t.Helper()
+	pollLiveDB(t, ctx, e, 60*time.Second, "category removal from manga", func(dbPath string) bool {
+		db, err := harness.OpenAppDB(dbPath)
+		if err != nil {
+			return false
+		}
+		defer db.Close()
+		names, err := harness.MangaCategoryNames(db, title)
+		return err == nil && !slices.Contains(names, category)
 	})
 }
 

--- a/e2e/scenarios/suwayomi_test.go
+++ b/e2e/scenarios/suwayomi_test.go
@@ -6,15 +6,17 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/SyncYomi/SyncYomi/e2e/harness"
+	"github.com/SyncYomi/SyncYomi/internal/backup/pb"
 )
 
-// TestS7_AndroidSuwayomiBothDirections: Android app syncs its library up, the
-// Suwayomi server pulls it in, and Android picks up a Suwayomi-side sync back.
-func TestS7_AndroidSuwayomiBothDirections(t *testing.T) {
+// suwayomiJar locates the Suwayomi shadowJar, skipping the test when absent.
+func suwayomiJar(t *testing.T) string {
+	t.Helper()
 	jar := os.Getenv("E2E_SUWAYOMI_JAR")
 	if jar == "" {
 		home, _ := os.UserHomeDir()
@@ -26,7 +28,35 @@ func TestS7_AndroidSuwayomiBothDirections(t *testing.T) {
 	if jar == "" {
 		t.Skip("E2E_SUWAYOMI_JAR not set and no jar found; skipping")
 	}
+	return jar
+}
 
+func startSuwayomi(t *testing.T, ctx context.Context, srv *harness.SyncServer) *harness.Suwayomi {
+	t.Helper()
+	suwa, err := harness.StartSuwayomi(ctx, suwayomiJar(t), srv, filepath.Join(artifactDir, harness.SanitizeName(t.Name())))
+	if err != nil {
+		t.Fatalf("start suwayomi: %v", err)
+	}
+	t.Cleanup(suwa.Stop)
+	return suwa
+}
+
+// suwaSync triggers a Suwayomi sync and waits for it to succeed.
+func suwaSync(t *testing.T, ctx context.Context, suwa *harness.Suwayomi) {
+	t.Helper()
+	if result, err := suwa.StartSync(ctx); err != nil {
+		t.Fatalf("startSync: %v", err)
+	} else if result != "SUCCESS" {
+		t.Fatalf("startSync result = %s", result)
+	}
+	if err := suwa.WaitForSyncSuccess(ctx, 2*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestS7_AndroidSuwayomiBothDirections: Android app syncs its library up, the
+// Suwayomi server pulls it in, and Android picks up a Suwayomi-side sync back.
+func TestS7_AndroidSuwayomiBothDirections(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
@@ -38,11 +68,7 @@ func TestS7_AndroidSuwayomiBothDirections(t *testing.T) {
 	syncViaBroadcast(t, ctx, emuA, srv)
 	awaitLibrary(t, ctx, emuA, fixtureAManga)
 
-	suwa, err := harness.StartSuwayomi(ctx, jar, srv, filepath.Join(artifactDir, harness.SanitizeName(t.Name())))
-	if err != nil {
-		t.Fatalf("start suwayomi: %v", err)
-	}
-	t.Cleanup(suwa.Stop)
+	suwa := startSuwayomi(t, ctx, srv)
 
 	if result, err := suwa.StartSync(ctx); err != nil {
 		t.Fatalf("startSync: %v", err)
@@ -78,5 +104,151 @@ func TestS7_AndroidSuwayomiBothDirections(t *testing.T) {
 	}
 	if !sameStringSet(gotA, want) {
 		t.Errorf("android library after round-trip = %v, want %v", gotA, want)
+	}
+}
+
+// TestS14_SuwayomiCoreConvergence: Suwayomi applies the same core edits the
+// Android scenarios cover — read progress, category rename, membership moves,
+// and deletion tombstones — and pushes its own edits back, all over GraphQL.
+func TestS14_SuwayomiCoreConvergence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv)
+	seedServer(t, ctx, srv, "E2E Alpha")
+
+	suwa := startSuwayomi(t, ctx, srv)
+	suwaSync(t, ctx, suwa)
+	assertSuwaLibrarySize(t, ctx, suwa, fixtureAManga)
+
+	// Remote core edits: chapters read, category rename (same uid), a new
+	// category with a membership move.
+	edits := harness.FixtureBackup("E2E Alpha", fixtureAManga, fixtureAChapters)
+	harness.MarkChaptersRead(edits, "E2E Alpha 01", fixtureAChapters)
+	edits.BackupCategories[0].Name = "E2E Renamed"
+	edits.BackupCategories[0].Version = 1
+	zeta := &pb.BackupCategory{Name: "E2E Zeta", Order: 1, Id: 2, Uid: harness.FixtureCategoryUID("E2E Zeta"), Version: 1}
+	edits.BackupCategories = append(edits.BackupCategories, zeta)
+	for _, m := range edits.BackupManga {
+		if m.Title == "E2E Alpha 02" {
+			m.Categories = []int64{zeta.Order}
+			m.Version = 2
+		}
+	}
+	c := harness.NewSyntheticClient(srv, "e2e-suwa-edits")
+	if _, err := c.Merge(ctx, edits, harness.MergeOptions{}); err != nil {
+		t.Fatalf("edits merge: %v", err)
+	}
+
+	suwaSync(t, ctx, suwa)
+	library, err := suwa.Library(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTitle := map[string]harness.SuwayomiManga{}
+	for _, m := range library {
+		byTitle[m.Title] = m
+	}
+	if got := byTitle["E2E Alpha 01"].ReadCount; got != fixtureAChapters {
+		t.Errorf("suwayomi read count for Alpha 01 = %d, want %d", got, fixtureAChapters)
+	}
+	if got := byTitle["E2E Alpha 02"].Categories; !slices.Contains(got, "E2E Zeta") {
+		t.Errorf("suwayomi Alpha 02 categories = %v, want to contain E2E Zeta", got)
+	}
+	cats, err := suwa.CategoryNames(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(cats, "E2E Renamed") || slices.Contains(cats, "E2E Alpha") {
+		t.Errorf("suwayomi categories = %v, want rename E2E Alpha -> E2E Renamed applied", cats)
+	}
+
+	// Reverse direction: Suwayomi marks another manga read and pushes it.
+	if err := suwa.MarkChaptersRead(ctx, "E2E Alpha 03"); err != nil {
+		t.Fatal(err)
+	}
+	suwaSync(t, ctx, suwa)
+	snap, err := srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshotReadCount(snap, "E2E Alpha 03"); got != fixtureAChapters {
+		t.Errorf("server read count for Alpha 03 after suwayomi push = %d, want %d", got, fixtureAChapters)
+	}
+
+	// Tombstone: the category deletion reaches Suwayomi without taking manga along.
+	if _, err := c.Merge(ctx, nil, harness.MergeOptions{DeletedCategories: []int64{zeta.Uid}}); err != nil {
+		t.Fatalf("tombstone merge: %v", err)
+	}
+	suwaSync(t, ctx, suwa)
+	cats, err = suwa.CategoryNames(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(cats, "E2E Zeta") {
+		t.Errorf("suwayomi still has E2E Zeta after tombstone: %v", cats)
+	}
+	assertSuwaLibrarySize(t, ctx, suwa, fixtureAManga)
+}
+
+// TestS15_CrossPlatformDeepSync: edits made on Android through the real UI
+// (read progress, category create + assign) reach Suwayomi, and a
+// Suwayomi-side edit comes back to Android.
+func TestS15_CrossPlatformDeepSync(t *testing.T) {
+	suwayomiJar(t) // skip early when no jar is available
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	srv := startServer(t, mainPort)
+	harness.CollectOnFailure(t, artifactDir, srv, emuA)
+	seedServer(t, ctx, srv, "E2E Alpha")
+	resetApp(t, ctx, emuA, srv)
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitLibrary(t, ctx, emuA, fixtureAManga)
+
+	// Android-side edits through the real UI.
+	if err := emuA.RunFlow(ctx, harness.FlowPath("mark_read.yaml"), artifactDir,
+		map[string]string{"TITLE": "E2E Alpha 01"}); err != nil {
+		t.Fatalf("mark_read flow: %v", err)
+	}
+	awaitReadCount(t, ctx, emuA, "E2E Alpha 01", fixtureAChapters)
+	createAndAssign(t, ctx, srv, "E2E Zeta", "E2E Alpha 03")
+
+	suwa := startSuwayomi(t, ctx, srv)
+	suwaSync(t, ctx, suwa)
+	library, err := suwa.Library(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTitle := map[string]harness.SuwayomiManga{}
+	for _, m := range library {
+		byTitle[m.Title] = m
+	}
+	if got := byTitle["E2E Alpha 01"].ReadCount; got != fixtureAChapters {
+		t.Errorf("suwayomi read count for Alpha 01 = %d, want %d", got, fixtureAChapters)
+	}
+	if got := byTitle["E2E Alpha 03"].Categories; !slices.Contains(got, "E2E Zeta") {
+		t.Errorf("suwayomi Alpha 03 categories = %v, want to contain E2E Zeta", got)
+	}
+
+	// Suwayomi-side edit back to Android.
+	if err := suwa.MarkChaptersRead(ctx, "E2E Alpha 05"); err != nil {
+		t.Fatal(err)
+	}
+	suwaSync(t, ctx, suwa)
+	syncViaBroadcast(t, ctx, emuA, srv)
+	awaitReadCount(t, ctx, emuA, "E2E Alpha 05", fixtureAChapters)
+}
+
+func assertSuwaLibrarySize(t *testing.T, ctx context.Context, suwa *harness.Suwayomi, want int) {
+	t.Helper()
+	titles, err := suwa.LibraryTitles(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(titles) != want {
+		t.Fatalf("suwayomi library has %d entries, want %d: %v", len(titles), want, titles)
 	}
 }

--- a/e2e/scenarios/suwayomi_test.go
+++ b/e2e/scenarios/suwayomi_test.go
@@ -153,8 +153,8 @@ func TestS14_SuwayomiCoreConvergence(t *testing.T) {
 	if got := byTitle["E2E Alpha 01"].ReadCount; got != fixtureAChapters {
 		t.Errorf("suwayomi read count for Alpha 01 = %d, want %d", got, fixtureAChapters)
 	}
-	if got := byTitle["E2E Alpha 02"].Categories; !slices.Contains(got, "E2E Zeta") {
-		t.Errorf("suwayomi Alpha 02 categories = %v, want to contain E2E Zeta", got)
+	if got := byTitle["E2E Alpha 02"].Categories; !slices.Contains(got, "E2E Zeta") || slices.Contains(got, "E2E Renamed") {
+		t.Errorf("suwayomi Alpha 02 categories = %v, want a MOVE to E2E Zeta (old membership removed)", got)
 	}
 	cats, err := suwa.CategoryNames(ctx)
 	if err != nil {
@@ -162,6 +162,10 @@ func TestS14_SuwayomiCoreConvergence(t *testing.T) {
 	}
 	if !slices.Contains(cats, "E2E Renamed") || slices.Contains(cats, "E2E Alpha") {
 		t.Errorf("suwayomi categories = %v, want rename E2E Alpha -> E2E Renamed applied", cats)
+	}
+	// Server orders: Renamed=0, Zeta=1 — Suwayomi must hold the same positions.
+	if ri, zi := slices.Index(cats, "E2E Renamed"), slices.Index(cats, "E2E Zeta"); ri > zi {
+		t.Errorf("suwayomi category order = %v, want E2E Renamed before E2E Zeta", cats)
 	}
 
 	// Reverse direction: Suwayomi marks another manga read and pushes it.
@@ -214,7 +218,19 @@ func TestS15_CrossPlatformDeepSync(t *testing.T) {
 		t.Fatalf("mark_read flow: %v", err)
 	}
 	awaitReadCount(t, ctx, emuA, "E2E Alpha 01", fixtureAChapters)
-	createAndAssign(t, ctx, srv, "E2E Zeta", "E2E Alpha 03")
+
+	// True category MOVE through the real UI: check Zeta, uncheck Alpha.
+	if err := emuA.RunFlow(ctx, harness.FlowPath("create_category.yaml"), artifactDir,
+		map[string]string{"NAME": "E2E Zeta"}); err != nil {
+		t.Fatalf("create category flow: %v", err)
+	}
+	if err := emuA.RunFlow(ctx, harness.FlowPath("move_category.yaml"), artifactDir,
+		map[string]string{"TITLE": "E2E Alpha 03", "NEW": "E2E Zeta", "OLD": "E2E Alpha"}); err != nil {
+		t.Fatalf("move category flow: %v", err)
+	}
+	awaitMangaInCategory(t, ctx, emuA, "E2E Alpha 03", "E2E Zeta")
+	awaitMangaNotInCategory(t, ctx, emuA, "E2E Alpha 03", "E2E Alpha")
+	syncViaBroadcast(t, ctx, emuA, srv)
 
 	suwa := startSuwayomi(t, ctx, srv)
 	suwaSync(t, ctx, suwa)
@@ -229,8 +245,8 @@ func TestS15_CrossPlatformDeepSync(t *testing.T) {
 	if got := byTitle["E2E Alpha 01"].ReadCount; got != fixtureAChapters {
 		t.Errorf("suwayomi read count for Alpha 01 = %d, want %d", got, fixtureAChapters)
 	}
-	if got := byTitle["E2E Alpha 03"].Categories; !slices.Contains(got, "E2E Zeta") {
-		t.Errorf("suwayomi Alpha 03 categories = %v, want to contain E2E Zeta", got)
+	if got := byTitle["E2E Alpha 03"].Categories; !slices.Contains(got, "E2E Zeta") || slices.Contains(got, "E2E Alpha") {
+		t.Errorf("suwayomi Alpha 03 categories = %v, want a MOVE to E2E Zeta (E2E Alpha removed)", got)
 	}
 
 	// Suwayomi-side edit back to Android.

--- a/e2e/scripts/doctor.sh
+++ b/e2e/scripts/doctor.sh
@@ -19,8 +19,9 @@ echo "SyncYomi E2E doctor"
 command -v adb >/dev/null && ok "adb: $(adb --version | head -1)" || bad "adb not on PATH"
 [ -x "$SDK/emulator/emulator" ] && ok "emulator: $("$SDK/emulator/emulator" -version 2>/dev/null | head -1)" || bad "emulator not installed (run setup-env.sh)"
 [ -d "$SDK/system-images/android-35/google_apis/x86_64" ] && ok "system image android-35 google_apis x86_64" || bad "system image missing (run setup-env.sh)"
+AVD_HOME="${ANDROID_AVD_HOME:-$HOME/.android/avd}"
 for avd in syncE2E-a syncE2E-b; do
-    [ -d "$HOME/.android/avd/$avd.avd" ] && ok "AVD $avd" || bad "AVD $avd missing (run setup-env.sh)"
+    [ -f "$AVD_HOME/$avd.ini" ] && ok "AVD $avd" || bad "AVD $avd missing (run setup-env.sh)"
 done
 [ -x "$E2E_DIR/.tools/maestro/bin/maestro" ] && ok "maestro: $("$E2E_DIR/.tools/maestro/bin/maestro" --version 2>/dev/null)" || bad "maestro missing (run setup-env.sh)"
 command -v java >/dev/null && ok "java: $(java -version 2>&1 | head -1)" || bad "java not on PATH (maestro needs 17+)"

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -12,4 +12,5 @@ fi
 
 "$E2E_DIR/scripts/doctor.sh" || { echo "[run-e2e] doctor failed"; exit 1; }
 
-exec go test -C "$REPO_DIR" -tags e2e ./e2e/scenarios/... -v -timeout 60m "$@"
+# -count=1 so a green run is always a real run, never Go's cached result
+exec go test -C "$REPO_DIR" -tags e2e -count=1 ./e2e/scenarios/... -v -timeout 60m "$@"

--- a/e2e/scripts/setup-env.sh
+++ b/e2e/scripts/setup-env.sh
@@ -35,14 +35,20 @@ else
     log "system image already installed"
 fi
 
+AVD_HOME="${ANDROID_AVD_HOME:-$HOME/.android/avd}"
+
 create_avd() {
-    local name="$1" avd_dir="$HOME/.android/avd/$1.avd"
-    if [ -d "$avd_dir" ]; then
+    local name="$1" ini="$AVD_HOME/$1.ini"
+    if [ -f "$ini" ]; then
         log "AVD $name already exists"
     else
         log "creating AVD $name"
-        echo no | "$AVDMANAGER" create avd -n "$name" -k "$SYSIMG" -d pixel_6 >/dev/null
+        echo no | "$AVDMANAGER" create avd -n "$name" -k "$SYSIMG" -d pixel_6
     fi
+    # avdmanager records the actual AVD directory in the .ini — don't assume it.
+    local avd_dir
+    avd_dir="$(grep '^path=' "$ini" | head -1 | cut -d= -f2-)"
+    [ -n "$avd_dir" ] && [ -d "$avd_dir" ] || die "AVD dir for $name not found (ini: $ini)"
     local cfg="$avd_dir/config.ini"
     # Idempotent config pinning: drop any prior value, append ours.
     for kv in "hw.ramSize=2048" "disk.dataPartition.size=6G" "hw.keyboard=yes" "hw.gpu.enabled=yes" "hw.gpu.mode=swiftshader_indirect"; do

--- a/e2e/scripts/setup-env.sh
+++ b/e2e/scripts/setup-env.sh
@@ -35,7 +35,11 @@ else
     log "system image already installed"
 fi
 
-AVD_HOME="${ANDROID_AVD_HOME:-$HOME/.android/avd}"
+# Pin the AVD location so avdmanager and the emulator agree everywhere (CI
+# runners otherwise place AVDs in surprising directories).
+export ANDROID_AVD_HOME="${ANDROID_AVD_HOME:-$HOME/.android/avd}"
+AVD_HOME="$ANDROID_AVD_HOME"
+mkdir -p "$AVD_HOME"
 
 create_avd() {
     local name="$1" ini="$AVD_HOME/$1.ini"


### PR DESCRIPTION
Extends the E2E suite with category rename/reorder/create/assign/delete scenarios driven through the real TachiyomiSY UI, Suwayomi core-convergence and deep cross-platform scenarios over GraphQL, and a GitHub Actions workflow that runs the whole suite nightly, on demand and on sync-path PRs.