### PR TITLE
test(e2e): cover Suwayomi send-side category wire orders in S14

### DIFF
--- a/e2e/harness/suwayomi.go
+++ b/e2e/harness/suwayomi.go
@@ -269,6 +269,87 @@ func (s *Suwayomi) CategoryNames(ctx context.Context) ([]string, error) {
 	return names, nil
 }
 
+// CreateCategoryAt creates a category at the given 1-based position, shifting
+// existing categories down, and returns its id.
+func (s *Suwayomi) CreateCategoryAt(ctx context.Context, name string, position int) (int, error) {
+	var out struct {
+		Data struct {
+			CreateCategory struct {
+				Category struct {
+					ID int `json:"id"`
+				} `json:"category"`
+			} `json:"createCategory"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	err := s.GraphQL(ctx,
+		`mutation($name: String!, $order: Int) { createCategory(input: {name: $name, order: $order}) { category { id } } }`,
+		map[string]any{"name": name, "order": position}, &out)
+	if err != nil {
+		return 0, err
+	}
+	if len(out.Errors) > 0 {
+		return 0, fmt.Errorf("createCategory: %s", out.Errors[0].Message)
+	}
+	return out.Data.CreateCategory.Category.ID, nil
+}
+
+// AddMangaToCategory adds the manga with the given title to the named category.
+func (s *Suwayomi) AddMangaToCategory(ctx context.Context, title, category string) error {
+	library, err := s.Library(ctx)
+	if err != nil {
+		return err
+	}
+	mangaID := 0
+	for _, m := range library {
+		if m.Title == title {
+			mangaID = m.ID
+		}
+	}
+	if mangaID == 0 {
+		return fmt.Errorf("no library manga titled %q", title)
+	}
+	var cats struct {
+		Data struct {
+			Categories struct {
+				Nodes []struct {
+					ID   int    `json:"id"`
+					Name string `json:"name"`
+				} `json:"nodes"`
+			} `json:"categories"`
+		} `json:"data"`
+	}
+	if err := s.GraphQL(ctx, `{ categories { nodes { id name } } }`, nil, &cats); err != nil {
+		return err
+	}
+	categoryID := -1
+	for _, c := range cats.Data.Categories.Nodes {
+		if c.Name == category {
+			categoryID = c.ID
+		}
+	}
+	if categoryID < 0 {
+		return fmt.Errorf("no category named %q", category)
+	}
+	var out struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	err = s.GraphQL(ctx,
+		`mutation($id: Int!, $cats: [Int!]!) { updateMangaCategories(input: {id: $id, patch: {addToCategories: $cats}}) { clientMutationId } }`,
+		map[string]any{"id": mangaID, "cats": []int{categoryID}}, &out)
+	if err != nil {
+		return err
+	}
+	if len(out.Errors) > 0 {
+		return fmt.Errorf("updateMangaCategories: %s", out.Errors[0].Message)
+	}
+	return nil
+}
+
 // MarkChaptersRead flips all chapters of the given manga to read via GraphQL.
 func (s *Suwayomi) MarkChaptersRead(ctx context.Context, title string) error {
 	library, err := s.Library(ctx)

--- a/e2e/scenarios/suwayomi_test.go
+++ b/e2e/scenarios/suwayomi_test.go
@@ -163,7 +163,8 @@ func TestS14_SuwayomiCoreConvergence(t *testing.T) {
 	if !slices.Contains(cats, "E2E Renamed") || slices.Contains(cats, "E2E Alpha") {
 		t.Errorf("suwayomi categories = %v, want rename E2E Alpha -> E2E Renamed applied", cats)
 	}
-	// Server orders: Renamed=0, Zeta=1 — Suwayomi must hold the same positions.
+	// Server orders: Renamed=0, Zeta=1 — Suwayomi ranks them 1-based after
+	// Default but must keep the same relative positions.
 	if ri, zi := slices.Index(cats, "E2E Renamed"), slices.Index(cats, "E2E Zeta"); ri > zi {
 		t.Errorf("suwayomi category order = %v, want E2E Renamed before E2E Zeta", cats)
 	}
@@ -194,6 +195,38 @@ func TestS14_SuwayomiCoreConvergence(t *testing.T) {
 		t.Errorf("suwayomi still has E2E Zeta after tombstone: %v", cats)
 	}
 	assertSuwaLibrarySize(t, ctx, suwa, fixtureAManga)
+
+	// Send side: a category created on Suwayomi above E2E Renamed (position 1,
+	// after Default) must reach the server as 0-based contiguous wire orders
+	// with manga refs remapped through the same rebase.
+	if _, err := suwa.CreateCategoryAt(ctx, "E2E Suwa", 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := suwa.AddMangaToCategory(ctx, "E2E Alpha 02", "E2E Suwa"); err != nil {
+		t.Fatal(err)
+	}
+	suwaSync(t, ctx, suwa)
+	snap, err = srv.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshotCategoryOrder(snap); !slices.Equal(got, []string{"E2E Suwa", "E2E Renamed"}) {
+		t.Errorf("server category order after suwayomi push = %v, want [E2E Suwa, E2E Renamed]", got)
+	}
+	orders := make([]int64, 0, len(snap.BackupCategories))
+	for _, c := range snap.BackupCategories {
+		orders = append(orders, c.Order)
+	}
+	slices.Sort(orders)
+	for i, o := range orders {
+		if o != int64(i) {
+			t.Errorf("server category orders = %v, want 0-based contiguous", orders)
+			break
+		}
+	}
+	if !snapshotMangaInCategory(snap, "E2E Alpha 02", "E2E Suwa") {
+		t.Errorf("server missing E2E Alpha 02 in E2E Suwa after suwayomi push")
+	}
 }
 
 // TestS15_CrossPlatformDeepSync: edits made on Android through the real UI


### PR DESCRIPTION
Extends S14 to assert that a category created on the Suwayomi side reaches the server with 0-based contiguous wire orders and remapped manga refs, and fixes the stale restore-side comment.