### PR TITLE
fix: restore v1 protocol compatibility with blob-echo semantics

### DIFF
--- a/.github/workflows/e2e-v1.yml
+++ b/.github/workflows/e2e-v1.yml
@@ -1,0 +1,58 @@
+name: e2e-v1
+
+# The v1 protocol suite is server-only (no emulators, APKs or Suwayomi) and runs in
+# minutes; it stays deliberately separate from the full e2e workflow.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "internal/**"
+      - "proto/**"
+      - "e2e/**"
+      - "main.go"
+      - "go.mod"
+      - ".github/workflows/e2e-v1.yml"
+
+concurrency:
+  group: e2e-v1-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-v1:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: ".node-version"
+
+      - name: Set up corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v7
+        with:
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Build web/dist
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          CI= pnpm run build
+
+      - name: Run v1 E2E suite
+        run: e2e/scripts/run-e2e-v1.sh
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-v1-failure-artifacts
+          path: e2e/artifacts/
+          retention-days: 7

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -5,12 +5,15 @@ the combinations behave.
 
 ## Compatibility
 
-| Client                                | Server < 1.3                                | Server ≥ 1.3                         |
-| ------------------------------------- | ------------------------------------------- | ------------------------------------ |
-| v1 client (`GET`/`PUT /sync/content`) | works, client-side merge                    | works, server-side merge, deprecated |
-| v2 client                             | falls back to v1 (capabilities returns 404) | v2                                   |
+| Client                                | Server < 1.3                                | Server ≥ 1.6                                        |
+| ------------------------------------- | ------------------------------------------- | --------------------------------------------------- |
+| v1 client (`GET`/`PUT /sync/content`) | works, client-side merge                    | works, client-side merge (blob echo), deprecated    |
+| v2 client                             | falls back to v1 (capabilities returns 404) | v2                                                  |
 
-A library can be shared by v1 and v2 clients at the same time.
+A library can be shared by v1 and v2 clients at the same time. Between v1 clients the server
+echoes the uploaded bytes verbatim, so their client-side merge behaves exactly as on old
+servers; only when a v2 device writes on the same key does a v1 `GET` receive a
+server-rendered backup — that is the one case where the zero-default warning below matters.
 
 ## Implementing v2
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -56,6 +56,7 @@ One row per merged item. `kind` is one of `manga`, `chapter`, `category`, `sourc
 | `payload` | the item's protobuf message (a manga payload carries neither chapters nor category numbers) |
 | `seq` | the key's `sync_state.seq` at the last change of this row |
 | `origin_device` | device that made the last change (`legacy`, `migration`, `restore` for server-side writes) |
+| `modified_at` | the payload's `last_modified_at`, the tiebreaker for equal-version conflicts |
 
 The server never parses the payload beyond what the merge keys need, which is what will let
 end-to-end encryption reuse the same store.
@@ -67,14 +68,23 @@ by that request carry the new `seq`. A client's cursor is the `seq` it last saw;
 receives is `seq > cursor` (plus all categories). `sync_device.last_cursor` records it per
 device for the web UI.
 
-## Render cache and history
+## Raw blob, render cache and history
 
-`sync_data` holds the last full backup rendered from the item store together with the `seq`
-it was rendered at (`rendered_seq`). It is refreshed after every write and serves v1 clients
-and the v2 snapshot endpoint. Each refresh also lands in `sync_data_history`
-(`syncHistoryLimit` entries), which is what *Restore* in the web UI rebuilds the store from.
+`sync_data` carries two payloads per key. `raw_data`/`raw_etag`/`raw_seq` hold the last v1
+client upload byte-for-byte: while `raw_seq` still equals `sync_state.seq` (no other device
+has written since), a v1 `GET` echoes exactly those bytes under their `uuid=` etag, so v1
+fleets keep the pre-1.3 semantics where the client-side merge is authoritative.
+`data`/`data_etag`/`rendered_seq` hold the last full backup rendered from the item store; it
+serves the v2 snapshot endpoint, and v1 clients only when the raw blob is stale. Renders
+refresh lazily on the first read after a change.
 
-A `sync_data` row with `rendered_seq = NULL` is a blob written by a pre-v2 server. On the
-first request for that key after the upgrade it is decoded and imported into `sync_item`
-(device `migration`); if it cannot be decoded the raw blob keeps being served to v1 clients
-and the item store starts empty.
+Both v1 uploads and render refreshes land in `sync_data_history` (`syncHistoryLimit`
+entries): `uuid=` entries are device uploads, `seq=` entries are server renders. *Restore*
+in the web UI rebuilds the item store from an entry and installs its bytes as the raw blob,
+so v1 devices receive it verbatim.
+
+A `sync_data` row with `rendered_seq = NULL` and no raw blob is a payload written by a
+pre-1.3 server. On the first request for that key after the upgrade it is promoted to the
+raw blob (keeping its original `uuid=` etag) and imported into `sync_item` (device
+`migration`); if it cannot be decoded it keeps being served to v1 clients verbatim, is never
+overwritten by renders, and the item store starts empty.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -35,11 +35,32 @@ Back up the config directory (SQLite) or take a PostgreSQL dump. Sync payloads a
 
 ## Rolling back sync data
 
-Every upload keeps the previous payload (up to `syncHistoryLimit`). In the web UI, open *Settings → API Keys → Details* for the key and pick *Restore* on an older entry. The restored payload becomes current under a new ETag; each device downloads it on its next sync (a device that tries to upload with a stale `If-Match` gets `412` and re-syncs).
+Every upload keeps the previous payload (up to `syncHistoryLimit`). In the web UI, open *Settings → API Keys → Details* for the key and pick *Restore* on an older entry. The restored payload becomes current under a new ETag; each device downloads it on its next sync (a device that tries to upload with a stale `If-Match` gets `412` and re-syncs). Each entry can also be downloaded; entries marked *device upload* are complete backup files the apps can import directly.
 
 The same view shows which devices have synced with the key, when they were last seen and the last status they reported. Devices appear once they report sync events or send the `X-Device-ID`/`X-Device-Name` headers.
 
 ## Upgrade notes
+
+### 1.6.0
+
+- The v1 endpoints store and serve client uploads byte-for-byte again, as before 1.3.0:
+  `PUT /api/sync/content` keeps the exact bytes (and imports them into the item store on a
+  best-effort basis), `GET` echoes them until a v2 device writes. v1 ETags return to
+  `uuid=…`. Payloads that do not decode are accepted and served unchanged, like 1.1.x.
+- A pre-1.3 payload that cannot be decoded is no longer answered with 404 or overwritten by
+  a later upload; it is served verbatim until a device pushes a fresh library.
+- Equal-version conflicts now fall back to the payloads' `last_modified_at`, so clients that
+  never bump `version` (v1-era builds) propagate changes instead of being stuck at their
+  first upload forever.
+- If a library got stuck while syncing v1 clients through 1.3/1.4: restore a history entry
+  with a `uuid=…` etag (a device upload) from *Settings → API Keys → Details*, or push a
+  full library from the device with the most complete state.
+- Schema: `sync_data` gains `raw_data`/`raw_etag`/`raw_seq`, `sync_item` gains
+  `modified_at`, `sync_status` gains `last_protocol`. The migration runs automatically.
+- Web UI: keys with v1 devices are flagged with a banner and *legacy* chips; devices show
+  how many merges they are behind; history entries show their origin and can be downloaded;
+  stale devices can be forgotten. New admin endpoints `DELETE …/devices/{id}` and
+  `GET …/history/{id}/download`.
 
 ### 1.3.1
 

--- a/docs/sync-protocol-v2.md
+++ b/docs/sync-protocol-v2.md
@@ -119,14 +119,19 @@ flowchart TD
 
 ## Protocol v1 on a v2 server
 
-`GET /api/sync/content` serves the library rendered from the item store (cached until the
-next change); `PUT` merges the uploaded backup like a full v2 request from a device called
-`legacy`. `If-Match`/`If-None-Match` keep working with the new `seq=` ETags.
+`PUT /api/sync/content` stores the uploaded bytes verbatim as the key's raw blob and imports
+them into the item store on a best-effort basis (as a full request from a device called
+`legacy`; a payload that does not decode is stored and served anyway). `GET` echoes the raw
+blob byte-for-byte under its `uuid=` etag while no other device has written since, and only
+then falls back to a render of the item store (`seq=` etag). `If-Match`/`If-None-Match`
+keep working across both etag forms.
 
 Consequences for v1 clients:
 
-- Items a v1 client dropped through its absence rule come back from the server. This is the
-  correct outcome for the bug above.
-- Category deletions made on a v1 client do not propagate (there is no tombstone); deleting
-  the category on a v2 client does.
+- Two v1 devices exchange exactly the bytes they upload, like on a pre-1.3 server: their
+  client-side merge stays authoritative between them.
+- Once a v2 device writes on the same key, the next v1 `GET` receives a server render
+  containing both sides; the following v1 upload resumes the echo.
+- Category deletions made on a v1 client propagate to other v1 clients through the blob but
+  not into the item store (no tombstone); deleting the category on a v2 client does.
 - Every v1 response carries `Deprecation: true`; the web UI marks such devices as *legacy*.

--- a/e2e/harness/cmd/seed/main.go
+++ b/e2e/harness/cmd/seed/main.go
@@ -1,5 +1,7 @@
-// Command seed pushes a generated fixture backup to a running SyncYomi server
-// via the v2 merge endpoint, acting as a synthetic device. For manual testing.
+// Command seed pushes a generated fixture backup to a running SyncYomi server,
+// acting as a synthetic device. For manual testing. -protocol picks the v2 merge
+// endpoint (default) or the legacy v1 upload, which sends no device headers just
+// like real v1 clients.
 package main
 
 import (
@@ -9,6 +11,7 @@ import (
 	"os"
 
 	"github.com/SyncYomi/SyncYomi/e2e/harness"
+	"github.com/SyncYomi/SyncYomi/internal/backup"
 )
 
 func main() {
@@ -17,6 +20,8 @@ func main() {
 	prefix := flag.String("prefix", "E2E Alpha", "fixture title prefix")
 	manga := flag.Int("manga", 5, "manga count")
 	chapters := flag.Int("chapters", 3, "chapters per manga")
+	protocol := flag.String("protocol", "v2", "sync protocol to use: v1 or v2")
+	device := flag.String("device", "e2e-seed", "device id (v2 only)")
 	flag.Parse()
 	if *key == "" {
 		fmt.Fprintln(os.Stderr, "-key required")
@@ -24,12 +29,32 @@ func main() {
 	}
 
 	srv := &harness.SyncServer{BaseURL: *server, APIKey: *key}
-	c := harness.NewSyntheticClient(srv, "e2e-seed")
-	resp, err := c.Merge(context.Background(),
-		harness.FixtureBackup(*prefix, *manga, *chapters), harness.MergeOptions{Full: true})
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "merge:", err)
+	b := harness.FixtureBackup(*prefix, *manga, *chapters)
+
+	switch *protocol {
+	case "v2":
+		c := harness.NewSyntheticClient(srv, *device)
+		resp, err := c.Merge(context.Background(), b, harness.MergeOptions{Full: true})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "merge:", err)
+			os.Exit(1)
+		}
+		fmt.Printf("seeded; server cursor=%d, response manga=%d\n", c.Cursor, len(resp.BackupManga))
+	case "v1":
+		raw, err := backup.Encode(b)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "encode:", err)
+			os.Exit(1)
+		}
+		c := harness.NewSyntheticClient(srv, "")
+		etag, status, err := c.PutV1(context.Background(), raw, "", false)
+		if err != nil || status != 200 {
+			fmt.Fprintf(os.Stderr, "v1 put: status %d err %v\n", status, err)
+			os.Exit(1)
+		}
+		fmt.Printf("seeded via v1; etag=%s size=%d\n", etag, len(raw))
+	default:
+		fmt.Fprintln(os.Stderr, "-protocol must be v1 or v2")
 		os.Exit(1)
 	}
-	fmt.Printf("seeded; server cursor=%d, response manga=%d\n", c.Cursor, len(resp.BackupManga))
 }

--- a/e2e/harness/server.go
+++ b/e2e/harness/server.go
@@ -30,6 +30,7 @@ type SyncServer struct {
 	Port    int
 
 	cmd     *exec.Cmd
+	bin     string
 	logFile *os.File
 	admin   *http.Client
 }
@@ -84,6 +85,7 @@ func StartServer(ctx context.Context, repoRoot, artifactDir string, port int) (*
 		DataDir: dataDir,
 		LogPath: logPath,
 		cmd:     cmd,
+		bin:     bin,
 		logFile: logFile,
 		admin:   &http.Client{Jar: jar, Timeout: 15 * time.Second},
 	}
@@ -177,6 +179,25 @@ func (s *SyncServer) AdminGet(ctx context.Context, path string, out any) error {
 		return fmt.Errorf("%s: status %d", path, resp.StatusCode)
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// Restart boots the server again on the same data dir, e.g. after editing the database
+// directly to fabricate pre-upgrade state. The provisioned API key stays valid.
+func (s *SyncServer) Restart(ctx context.Context) error {
+	s.Stop()
+	logFile, err := os.OpenFile(s.LogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, s.bin, "--config", s.DataDir)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return fmt.Errorf("restart server: %w", err)
+	}
+	s.cmd, s.logFile = cmd, logFile
+	return s.waitReady(ctx)
 }
 
 // HostURLForEmulator is the server URL as seen from inside an emulator.

--- a/e2e/harness/synthetic.go
+++ b/e2e/harness/synthetic.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -85,4 +86,69 @@ func (c *SyntheticClient) Merge(ctx context.Context, b *pb.Backup, opts MergeOpt
 		return &pb.Backup{}, nil
 	}
 	return backup.Decode(data)
+}
+
+// PutV1 uploads raw bytes through the deprecated v1 endpoint exactly as legacy clients
+// do: no device headers, optional If-Match, optionally gzip-encoded. Non-2xx statuses
+// are returned, not treated as errors, so tests can assert on them.
+func (c *SyntheticClient) PutV1(ctx context.Context, raw []byte, ifMatch string, gzipBody bool) (etag string, status int, err error) {
+	body := raw
+	if gzipBody {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		if _, err := gz.Write(raw); err != nil {
+			return "", 0, err
+		}
+		if err := gz.Close(); err != nil {
+			return "", 0, err
+		}
+		body = buf.Bytes()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		c.Server.BaseURL+"/api/sync/content", bytes.NewReader(body))
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("X-API-Token", c.Server.APIKey)
+	if ifMatch != "" {
+		req.Header.Set("If-Match", ifMatch)
+	}
+	if gzipBody {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.Header.Get("ETag"), resp.StatusCode, nil
+}
+
+// GetV1 fetches the v1 payload with an optional If-None-Match. The body is nil on 304/404.
+func (c *SyntheticClient) GetV1(ctx context.Context, ifNoneMatch string) (data []byte, etag string, status int, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		c.Server.BaseURL+"/api/sync/content", nil)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	req.Header.Set("X-API-Token", c.Server.APIKey)
+	if ifNoneMatch != "" {
+		req.Header.Set("If-None-Match", ifNoneMatch)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, resp.Header.Get("ETag"), resp.StatusCode, nil
+	}
+	data, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	return data, resp.Header.Get("ETag"), resp.StatusCode, nil
 }

--- a/e2e/scenarios/v1/main_test.go
+++ b/e2e/scenarios/v1/main_test.go
@@ -1,0 +1,43 @@
+//go:build e2e_v1
+
+// Package v1 exercises the deprecated v1 sync protocol over real HTTP against a freshly
+// built server. Unlike the main e2e suite it needs no emulators, APKs or Suwayomi, so it
+// runs in minutes and lives behind its own build tag and CI workflow.
+package v1
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/SyncYomi/SyncYomi/e2e/harness"
+)
+
+var artifactDir string
+
+func TestMain(m *testing.M) {
+	artifactDir = filepath.Join(harness.E2ERoot(), "artifacts", time.Now().Format("20060102-150405")+"-v1")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("artifacts:", artifactDir)
+	os.Exit(m.Run())
+}
+
+// startServer boots a fresh SyncYomi server for one test and registers cleanup.
+func startServer(t *testing.T, port int) *harness.SyncServer {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	dir := filepath.Join(artifactDir, harness.SanitizeName(t.Name()), fmt.Sprintf("server-%d", port))
+	srv, err := harness.StartServer(ctx, harness.RepoRoot(), dir, port)
+	if err != nil {
+		t.Fatalf("start server on %d: %v", port, err)
+	}
+	t.Cleanup(srv.Stop)
+	return srv
+}

--- a/e2e/scenarios/v1/v1_test.go
+++ b/e2e/scenarios/v1/v1_test.go
@@ -1,0 +1,253 @@
+//go:build e2e_v1
+
+package v1
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SyncYomi/SyncYomi/e2e/harness"
+	"github.com/SyncYomi/SyncYomi/internal/backup"
+	_ "modernc.org/sqlite"
+)
+
+func encodeFixture(t *testing.T, prefix string, mangaCount, chapterCount int) []byte {
+	t.Helper()
+	raw, err := backup.Encode(harness.FixtureBackup(prefix, mangaCount, chapterCount))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// V1-S1: a v1 push comes back byte-identical with a uuid= etag, and If-None-Match 304s.
+func TestV1_EchoRoundTrip(t *testing.T) {
+	srv := startServer(t, 8795)
+	ctx := context.Background()
+	c := harness.NewSyntheticClient(srv, "")
+
+	// empty key: nothing to fetch yet
+	if _, _, status, err := c.GetV1(ctx, ""); err != nil || status != http.StatusNotFound {
+		t.Fatalf("initial get = %d, %v; want 404", status, err)
+	}
+
+	raw := encodeFixture(t, "s1", 5, 3)
+	etag, status, err := c.PutV1(ctx, raw, "", false)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("put = %d, %v", status, err)
+	}
+	if !strings.HasPrefix(etag, "uuid=") {
+		t.Fatalf("etag = %q, want uuid= prefix", etag)
+	}
+
+	data, gotTag, status, err := c.GetV1(ctx, "")
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("get = %d, %v", status, err)
+	}
+	if gotTag != etag {
+		t.Errorf("get etag = %q, put etag = %q", gotTag, etag)
+	}
+	if !bytes.Equal(data, raw) {
+		t.Fatal("v1 get is not byte-identical to the upload")
+	}
+
+	if _, _, status, err = c.GetV1(ctx, etag); err != nil || status != http.StatusNotModified {
+		t.Errorf("If-None-Match get = %d, %v; want 304", status, err)
+	}
+
+	// gzip-encoded upload lands identically
+	raw2 := encodeFixture(t, "s1b", 2, 1)
+	etag2, status, err := c.PutV1(ctx, raw2, etag, true)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("gzip put = %d, %v", status, err)
+	}
+	data, _, _, _ = c.GetV1(ctx, "")
+	if !bytes.Equal(data, raw2) || etag2 == etag {
+		t.Error("gzip upload not echoed")
+	}
+}
+
+// V1-S2: two v1 devices exchange state through the blob; If-Match protects against races.
+func TestV1_TwoDevices(t *testing.T) {
+	srv := startServer(t, 8796)
+	ctx := context.Background()
+	a := harness.NewSyntheticClient(srv, "")
+	b := harness.NewSyntheticClient(srv, "")
+
+	rawA := encodeFixture(t, "s2a", 4, 2)
+	etagA, status, err := a.PutV1(ctx, rawA, "", false)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("A put = %d, %v", status, err)
+	}
+
+	// B pulls A's exact bytes, merges locally (simulated), pushes the union
+	got, gotTag, _, err := b.GetV1(ctx, "")
+	if err != nil || !bytes.Equal(got, rawA) || gotTag != etagA {
+		t.Fatalf("B pull mismatch: etag=%q err=%v", gotTag, err)
+	}
+	merged := harness.FixtureBackup("s2a", 4, 2)
+	merged.BackupManga = append(merged.BackupManga, harness.FixtureBackup("s2b", 3, 1).BackupManga...)
+	rawB, _ := backup.Encode(merged)
+	etagB, status, err := b.PutV1(ctx, rawB, gotTag, false)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("B put = %d, %v", status, err)
+	}
+
+	// A pushing with its stale etag must 412, then pull B's bytes verbatim
+	if _, status, err = a.PutV1(ctx, rawA, etagA, false); err != nil || status != http.StatusPreconditionFailed {
+		t.Fatalf("stale If-Match = %d, %v; want 412", status, err)
+	}
+	got, gotTag, _, err = a.GetV1(ctx, "")
+	if err != nil || !bytes.Equal(got, rawB) || gotTag != etagB {
+		t.Fatal("A did not receive B's exact bytes")
+	}
+}
+
+// V1-S3: a database written by a pre-1.3 server keeps serving its blob after the upgrade,
+// even when the blob cannot be decoded, and a later valid upload takes over cleanly.
+func TestV1_LegacyUpgrade(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		port int
+		blob []byte
+	}{
+		{name: "decodable", port: 8797},
+		{name: "undecodable", port: 8798, blob: []byte{0xde, 0xad, 0xbe, 0xef, 0x02}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := startServer(t, tc.port)
+			ctx := context.Background()
+			c := harness.NewSyntheticClient(srv, "")
+
+			blob := tc.blob
+			if blob == nil {
+				blob = encodeFixture(t, "s3", 6, 2)
+			}
+
+			// fabricate 1.1.14 state: a bare sync_data row, no rendered_seq, no item store
+			srv.Stop()
+			db, err := sql.Open("sqlite", "file:"+filepath.Join(srv.DataDir, "syncyomi.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.Exec(
+				`INSERT INTO sync_data (user_api_key, data, data_etag) VALUES ($1, $2, 'uuid=legacy')`,
+				srv.APIKey, blob); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := srv.Restart(ctx); err != nil {
+				t.Fatal(err)
+			}
+
+			data, etag, status, err := c.GetV1(ctx, "")
+			if err != nil || status != http.StatusOK {
+				t.Fatalf("get after upgrade = %d, %v", status, err)
+			}
+			if !bytes.Equal(data, blob) || etag != "uuid=legacy" {
+				t.Fatal("legacy blob not served verbatim with its original etag")
+			}
+
+			// a valid upload replaces it without ever having destroyed it
+			raw := encodeFixture(t, "s3new", 2, 1)
+			newTag, status, err := c.PutV1(ctx, raw, etag, false)
+			if err != nil || status != http.StatusOK {
+				t.Fatalf("put after upgrade = %d, %v", status, err)
+			}
+			data, etag, _, _ = c.GetV1(ctx, "")
+			if !bytes.Equal(data, raw) || etag != newTag {
+				t.Fatal("upload after upgrade not echoed")
+			}
+		})
+	}
+}
+
+// V1-S4: a v2 write invalidates the raw blob (v1 falls back to a render containing both
+// sides), and the next v1 upload resumes the echo.
+func TestV1_MixedFleet(t *testing.T) {
+	srv := startServer(t, 8799)
+	ctx := context.Background()
+	v1 := harness.NewSyntheticClient(srv, "")
+	v2 := harness.NewSyntheticClient(srv, "e2e-v2-device")
+
+	raw := encodeFixture(t, "s4v1", 3, 2)
+	etag, status, err := v1.PutV1(ctx, raw, "", false)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("v1 put = %d, %v", status, err)
+	}
+
+	// v2 device merges its own library in
+	if _, err := v2.Merge(ctx, harness.FixtureBackup("s4v2", 2, 1), harness.MergeOptions{Full: true}); err != nil {
+		t.Fatalf("v2 merge: %v", err)
+	}
+
+	data, gotTag, status, err := v1.GetV1(ctx, "")
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("v1 get after v2 write = %d, %v", status, err)
+	}
+	if gotTag == etag || !strings.HasPrefix(gotTag, "seq=") {
+		t.Fatalf("etag after v2 write = %q, want a fresh seq= render", gotTag)
+	}
+	render, err := backup.Decode(data)
+	if err != nil {
+		t.Fatalf("render fallback does not decode: %v", err)
+	}
+	if len(render.BackupManga) != 5 {
+		t.Errorf("render has %d manga, want 5 (3 v1 + 2 v2)", len(render.BackupManga))
+	}
+
+	// v1 pushes its client-merged state: echo resumes
+	rawMerged, _ := backup.Encode(render)
+	newTag, status, err := v1.PutV1(ctx, rawMerged, gotTag, false)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("v1 re-put = %d, %v", status, err)
+	}
+	data, gotTag, _, _ = v1.GetV1(ctx, "")
+	if !bytes.Equal(data, rawMerged) || gotTag != newTag {
+		t.Fatal("echo did not resume after v1 upload")
+	}
+
+	// and the v2 device sees the v1 upload through the item store
+	resp, err := v2.Merge(ctx, nil, harness.MergeOptions{Full: true})
+	if err != nil {
+		t.Fatalf("v2 refetch: %v", err)
+	}
+	if len(resp.BackupManga) != 5 {
+		t.Errorf("v2 sees %d manga after v1 upload, want 5", len(resp.BackupManga))
+	}
+}
+
+// V1-S5: the error surface v1 clients depend on — garbage is accepted and echoed
+// (1.1.14 behaviour), never imported, and never served to v2.
+func TestV1_GarbageTolerated(t *testing.T) {
+	srv := startServer(t, 8800)
+	ctx := context.Background()
+	c := harness.NewSyntheticClient(srv, "")
+
+	garbage := []byte("not a protobuf at all")
+	etag, status, err := c.PutV1(ctx, garbage, "", false)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("garbage put = %d, %v; 1.1.14 accepted arbitrary bytes", status, err)
+	}
+	data, gotTag, _, err := c.GetV1(ctx, "")
+	if err != nil || !bytes.Equal(data, garbage) || gotTag != etag {
+		t.Fatal("garbage not echoed verbatim")
+	}
+
+	// a later valid upload recovers the key
+	raw := encodeFixture(t, "s5", 2, 1)
+	if _, status, err = c.PutV1(ctx, raw, gotTag, false); err != nil || status != http.StatusOK {
+		t.Fatalf("recovery put = %d, %v", status, err)
+	}
+	data, _, _, _ = c.GetV1(ctx, "")
+	if !bytes.Equal(data, raw) {
+		t.Fatal("recovery upload not echoed")
+	}
+}

--- a/e2e/scripts/run-e2e-v1.sh
+++ b/e2e/scripts/run-e2e-v1.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Runs the v1 protocol E2E suite: server-only, no emulators, APKs or Suwayomi.
+# Usage: run-e2e-v1.sh [-run <pattern>] [extra go test args...]
+set -euo pipefail
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_DIR="$(dirname "$E2E_DIR")"
+
+if [ ! -d "$REPO_DIR/web/dist" ]; then
+    echo "[run-e2e-v1] building web/dist (server embeds it)"
+    (cd "$REPO_DIR/web" && pnpm install --frozen-lockfile && pnpm build)
+fi
+
+# -count=1 so a green run is always a real run, never Go's cached result
+exec go test -C "$REPO_DIR" -tags e2e_v1 -count=1 ./e2e/scenarios/v1/... -v -timeout 10m "$@"

--- a/internal/backup/adapter.go
+++ b/internal/backup/adapter.go
@@ -46,7 +46,7 @@ func Split(b *pb.Backup) ([]*merge.Item, error) {
 		if err != nil {
 			return nil, err
 		}
-		items = append(items, &merge.Item{Kind: merge.KindCategory, Key: key, Name: c.Name, Version: c.Version, Payload: payload})
+		items = append(items, &merge.Item{Kind: merge.KindCategory, Key: key, Name: c.Name, Version: c.Version, ModifiedAt: c.GetLastModifiedAt(), Payload: payload})
 	}
 
 	for _, m := range b.BackupManga {
@@ -67,7 +67,7 @@ func Split(b *pb.Backup) ([]*merge.Item, error) {
 		if err != nil {
 			return nil, err
 		}
-		items = append(items, &merge.Item{Kind: merge.KindManga, Key: key, Version: m.Version, Refs: refs, Payload: payload})
+		items = append(items, &merge.Item{Kind: merge.KindManga, Key: key, Version: m.Version, ModifiedAt: m.GetLastModifiedAt(), Refs: refs, Payload: payload})
 
 		for _, ch := range m.Chapters {
 			if ch.Url == "" {
@@ -77,7 +77,7 @@ func Split(b *pb.Backup) ([]*merge.Item, error) {
 			if err != nil {
 				return nil, err
 			}
-			items = append(items, &merge.Item{Kind: merge.KindChapter, Key: ChapterKey(key, ch.Url), ParentKey: key, Version: ch.Version, Payload: payload})
+			items = append(items, &merge.Item{Kind: merge.KindChapter, Key: ChapterKey(key, ch.Url), ParentKey: key, Version: ch.Version, ModifiedAt: ch.GetLastModifiedAt(), Payload: payload})
 		}
 	}
 
@@ -126,8 +126,8 @@ func Split(b *pb.Backup) ([]*merge.Item, error) {
 }
 
 // dedupe keeps one item per (kind, key): backups can repeat a chapter url or a category,
-// and a single write must not touch the same row twice. The highest version wins, ties go
-// to the later occurrence.
+// and a single write must not touch the same row twice. The highest version wins, version
+// ties fall to the newer ModifiedAt, and full ties go to the later occurrence.
 func dedupe(items []*merge.Item) []*merge.Item {
 	type id struct {
 		kind merge.Kind
@@ -138,7 +138,8 @@ func dedupe(items []*merge.Item) []*merge.Item {
 	for _, it := range items {
 		k := id{it.Kind, it.Key}
 		if i, ok := index[k]; ok {
-			if it.Version >= out[i].Version {
+			cur := out[i]
+			if it.Version > cur.Version || (it.Version == cur.Version && it.ModifiedAt >= cur.ModifiedAt) {
 				out[i] = it
 			}
 			continue

--- a/internal/backup/adapter_test.go
+++ b/internal/backup/adapter_test.go
@@ -179,3 +179,30 @@ func TestSplitDedupesRepeatedKeys(t *testing.T) {
 		t.Errorf("later occurrence not kept for ties: %v %v", p, err)
 	}
 }
+
+func TestSplitPopulatesModifiedAt(t *testing.T) {
+	lm := int64(1700000000)
+	b := &pb.Backup{
+		BackupCategories: []*pb.BackupCategory{{Name: "A", Uid: 1, LastModifiedAt: lm}},
+		BackupManga: []*pb.BackupManga{
+			{Source: 1, Url: "/m", LastModifiedAt: lm + 1, Chapters: []*pb.BackupChapter{{Url: "/c", LastModifiedAt: lm + 2}}},
+			// version tie deduped by the newer timestamp
+			{Source: 1, Url: "/dup", LastModifiedAt: lm + 9},
+			{Source: 1, Url: "/dup", LastModifiedAt: lm + 3},
+		},
+	}
+	items, err := Split(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]int64{}
+	for _, it := range items {
+		got[string(it.Kind)+"|"+it.Key] = it.ModifiedAt
+	}
+	if got["category|uid:1"] != lm || got["manga|1|/m"] != lm+1 || got["chapter|"+ChapterKey("1|/m", "/c")] != lm+2 {
+		t.Errorf("ModifiedAt not extracted: %v", got)
+	}
+	if got["manga|1|/dup"] != lm+9 {
+		t.Errorf("dedupe kept the older timestamp: %v", got["manga|1|/dup"])
+	}
+}

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -55,6 +55,9 @@ CREATE TABLE sync_data
 	data BYTEA NOT NULL,
 	data_etag TEXT NOT NULL,
 	rendered_seq BIGINT,
+	raw_data BYTEA,
+	raw_etag TEXT,
+	raw_seq BIGINT,
 
 	FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 );
@@ -97,6 +100,7 @@ CREATE TABLE sync_status
 	last_status    TEXT NOT NULL DEFAULT '',
 	last_device    TEXT NOT NULL DEFAULT '',
 	last_message   TEXT NOT NULL DEFAULT '',
+	last_protocol  TEXT NOT NULL DEFAULT '',
 	FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 );
 
@@ -122,6 +126,7 @@ CREATE TABLE sync_item
     payload       BYTEA NOT NULL,
     seq           BIGINT NOT NULL,
     origin_device TEXT NOT NULL DEFAULT '',
+    modified_at   BIGINT NOT NULL DEFAULT 0,
     PRIMARY KEY (user_api_key, kind, key),
     FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 );
@@ -287,5 +292,12 @@ CREATE INDEX idx_sync_item_parent ON sync_item (user_api_key, kind, parent_key);
 ALTER TABLE sync_device ADD COLUMN last_cursor BIGINT NOT NULL DEFAULT 0;
 ALTER TABLE sync_device ADD COLUMN protocol TEXT NOT NULL DEFAULT '';
 ALTER TABLE sync_data ADD COLUMN rendered_seq BIGINT;
+`,
+	`
+ALTER TABLE sync_data ADD COLUMN raw_data BYTEA;
+ALTER TABLE sync_data ADD COLUMN raw_etag TEXT;
+ALTER TABLE sync_data ADD COLUMN raw_seq BIGINT;
+ALTER TABLE sync_item ADD COLUMN modified_at BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE sync_status ADD COLUMN last_protocol TEXT NOT NULL DEFAULT '';
 `,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -53,6 +53,9 @@ CREATE TABLE sync_data
     data BLOB NOT NULL,
     data_etag TEXT NOT NULL,
     rendered_seq INTEGER,
+    raw_data BLOB,
+    raw_etag TEXT,
+    raw_seq INTEGER,
 
     FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 );
@@ -95,6 +98,7 @@ CREATE TABLE sync_status
     last_status    TEXT NOT NULL DEFAULT '',
     last_device    TEXT NOT NULL DEFAULT '',
     last_message   TEXT NOT NULL DEFAULT '',
+    last_protocol  TEXT NOT NULL DEFAULT '',
     FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 );
 
@@ -120,6 +124,7 @@ CREATE TABLE sync_item
     payload       BLOB NOT NULL,
     seq           INTEGER NOT NULL,
     origin_device TEXT NOT NULL DEFAULT '',
+    modified_at   INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (user_api_key, kind, key),
     FOREIGN KEY (user_api_key) REFERENCES api_key (key) ON DELETE CASCADE
 );
@@ -310,5 +315,12 @@ CREATE INDEX idx_sync_item_parent ON sync_item (user_api_key, kind, parent_key);
 ALTER TABLE sync_device ADD COLUMN last_cursor INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE sync_device ADD COLUMN protocol TEXT NOT NULL DEFAULT '';
 ALTER TABLE sync_data ADD COLUMN rendered_seq INTEGER;
+`,
+	`
+ALTER TABLE sync_data ADD COLUMN raw_data BLOB;
+ALTER TABLE sync_data ADD COLUMN raw_etag TEXT;
+ALTER TABLE sync_data ADD COLUMN raw_seq INTEGER;
+ALTER TABLE sync_item ADD COLUMN modified_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sync_status ADD COLUMN last_protocol TEXT NOT NULL DEFAULT '';
 `,
 }

--- a/internal/database/sync.go
+++ b/internal/database/sync.go
@@ -252,7 +252,7 @@ func (r SyncRepo) TouchDevice(ctx context.Context, apiKey string, dev domain.Dev
 			last_event   = CASE WHEN EXCLUDED.last_event = '' THEN sync_device.last_event ELSE EXCLUDED.last_event END,
 			last_status  = CASE WHEN EXCLUDED.last_status = '' THEN sync_device.last_status ELSE EXCLUDED.last_status END,
 			last_message = CASE WHEN EXCLUDED.last_event = '' THEN sync_device.last_message ELSE EXCLUDED.last_message END,
-			protocol     = CASE WHEN EXCLUDED.protocol = '' THEN sync_device.protocol ELSE EXCLUDED.protocol END`,
+			protocol     = CASE WHEN sync_device.protocol = '' THEN EXCLUDED.protocol ELSE sync_device.protocol END`,
 		apiKey, deviceKey, dev.Name, now, event, status, message, protocol, now)
 	if err != nil {
 		return errors.Wrap(err, "error upserting device")

--- a/internal/database/sync.go
+++ b/internal/database/sync.go
@@ -236,7 +236,7 @@ func (r SyncRepo) GetHistoryData(ctx context.Context, apiKey string, id int) ([]
 	return data, nil
 }
 
-func (r SyncRepo) TouchDevice(ctx context.Context, apiKey string, dev domain.DeviceInfo, event, status, message string) error {
+func (r SyncRepo) TouchDevice(ctx context.Context, apiKey string, dev domain.DeviceInfo, event, status, message, protocol string) error {
 	deviceKey := dev.Key()
 	if deviceKey == "" {
 		return nil
@@ -244,19 +244,35 @@ func (r SyncRepo) TouchDevice(ctx context.Context, apiKey string, dev domain.Dev
 
 	now := time.Now().UTC()
 	_, err := r.db.handler.ExecContext(ctx, `
-		INSERT INTO sync_device (user_api_key, device_id, device_name, last_seen, last_event, last_status, last_message, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO sync_device (user_api_key, device_id, device_name, last_seen, last_event, last_status, last_message, protocol, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (user_api_key, device_id) DO UPDATE SET
 			device_name  = CASE WHEN EXCLUDED.device_name = '' THEN sync_device.device_name ELSE EXCLUDED.device_name END,
 			last_seen    = EXCLUDED.last_seen,
 			last_event   = CASE WHEN EXCLUDED.last_event = '' THEN sync_device.last_event ELSE EXCLUDED.last_event END,
 			last_status  = CASE WHEN EXCLUDED.last_status = '' THEN sync_device.last_status ELSE EXCLUDED.last_status END,
-			last_message = CASE WHEN EXCLUDED.last_event = '' THEN sync_device.last_message ELSE EXCLUDED.last_message END`,
-		apiKey, deviceKey, dev.Name, now, event, status, message, now)
+			last_message = CASE WHEN EXCLUDED.last_event = '' THEN sync_device.last_message ELSE EXCLUDED.last_message END,
+			protocol     = CASE WHEN EXCLUDED.protocol = '' THEN sync_device.protocol ELSE EXCLUDED.protocol END`,
+		apiKey, deviceKey, dev.Name, now, event, status, message, protocol, now)
 	if err != nil {
 		return errors.Wrap(err, "error upserting device")
 	}
 
+	return nil
+}
+
+func (r SyncRepo) DeleteDevice(ctx context.Context, apiKey string, id int) error {
+	result, err := r.db.squirrel.
+		Delete("sync_device").
+		Where(sq.Eq{"user_api_key": apiKey, "id": id}).
+		RunWith(r.db.handler).
+		ExecContext(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error deleting device")
+	}
+	if n, err := result.RowsAffected(); err == nil && n == 0 {
+		return domain.ErrNotFound
+	}
 	return nil
 }
 
@@ -287,16 +303,17 @@ func (r SyncRepo) ListDevices(ctx context.Context, apiKey string) ([]domain.Sync
 
 func (r SyncRepo) UpsertStatus(ctx context.Context, apiKey string, st domain.SyncStatus) error {
 	_, err := r.db.handler.ExecContext(ctx, `
-		INSERT INTO sync_status (user_api_key, last_synced_at, last_event_at, last_event, last_status, last_device, last_message)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO sync_status (user_api_key, last_synced_at, last_event_at, last_event, last_status, last_device, last_message, last_protocol)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (user_api_key) DO UPDATE SET
 			last_synced_at = COALESCE(EXCLUDED.last_synced_at, sync_status.last_synced_at),
 			last_event_at  = COALESCE(EXCLUDED.last_event_at, sync_status.last_event_at),
 			last_event     = CASE WHEN EXCLUDED.last_event = '' THEN sync_status.last_event ELSE EXCLUDED.last_event END,
 			last_status    = CASE WHEN EXCLUDED.last_status = '' THEN sync_status.last_status ELSE EXCLUDED.last_status END,
 			last_device    = CASE WHEN EXCLUDED.last_device = '' THEN sync_status.last_device ELSE EXCLUDED.last_device END,
-			last_message   = CASE WHEN EXCLUDED.last_event = '' THEN sync_status.last_message ELSE EXCLUDED.last_message END`,
-		apiKey, nullTime(st.LastSyncedAt), nullTime(st.LastEventAt), st.LastEvent, st.LastStatus, st.LastDevice, st.LastMessage)
+			last_message   = CASE WHEN EXCLUDED.last_event = '' THEN sync_status.last_message ELSE EXCLUDED.last_message END,
+			last_protocol  = CASE WHEN EXCLUDED.last_protocol = '' THEN sync_status.last_protocol ELSE EXCLUDED.last_protocol END`,
+		apiKey, nullTime(st.LastSyncedAt), nullTime(st.LastEventAt), st.LastEvent, st.LastStatus, st.LastDevice, st.LastMessage, st.LastProtocol)
 	if err != nil {
 		return errors.Wrap(err, "error upserting sync status")
 	}
@@ -312,12 +329,12 @@ func (r SyncRepo) GetStatus(ctx context.Context, apiKey string) (*domain.SyncSta
 
 	var lastSynced, lastEvent sql.NullTime
 	err := r.db.squirrel.
-		Select("last_synced_at", "last_event_at", "last_event", "last_status", "last_device", "last_message").
+		Select("last_synced_at", "last_event_at", "last_event", "last_status", "last_device", "last_message", "last_protocol").
 		From("sync_status").
 		Where(sq.Eq{"user_api_key": apiKey}).
 		RunWith(r.db.handler).
 		QueryRowContext(ctx).
-		Scan(&lastSynced, &lastEvent, &st.LastEvent, &st.LastStatus, &st.LastDevice, &st.LastMessage)
+		Scan(&lastSynced, &lastEvent, &st.LastEvent, &st.LastStatus, &st.LastDevice, &st.LastMessage, &st.LastProtocol)
 	switch {
 	case err == nil:
 		found = true
@@ -328,9 +345,10 @@ func (r SyncRepo) GetStatus(ctx context.Context, apiKey string) (*domain.SyncSta
 		return nil, errors.Wrap(err, "error executing query")
 	}
 
+	// the served payload: the raw v1 upload when one exists, else the render cache
 	var updatedAt sql.NullTime
 	err = r.db.squirrel.
-		Select("length(data)", "updated_at").
+		Select("COALESCE(length(raw_data), length(data))", "updated_at").
 		From("sync_data").
 		Where(sq.Eq{"user_api_key": apiKey}).
 		RunWith(r.db.handler).
@@ -345,10 +363,58 @@ func (r SyncRepo) GetStatus(ctx context.Context, apiKey string) (*domain.SyncSta
 		return nil, errors.Wrap(err, "error executing query")
 	}
 
+	err = r.db.squirrel.
+		Select("seq").
+		From("sync_state").
+		Where(sq.Eq{"user_api_key": apiKey}).
+		RunWith(r.db.handler).
+		QueryRowContext(ctx).
+		Scan(&st.Seq)
+	switch {
+	case err == nil:
+		found = true
+	case stderrors.Is(err, sql.ErrNoRows):
+	default:
+		return nil, errors.Wrap(err, "error executing query")
+	}
+
+	rows, err := r.db.squirrel.
+		Select("kind", "COUNT(*)").
+		From("sync_item").
+		Where(sq.Eq{"user_api_key": apiKey, "deleted": false}).
+		GroupBy("kind").
+		RunWith(r.db.handler).
+		QueryContext(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "error executing query")
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			kind  string
+			count int64
+		)
+		if err := rows.Scan(&kind, &count); err != nil {
+			return nil, errors.Wrap(err, "error scanning row")
+		}
+		switch kind {
+		case "manga":
+			st.MangaCount = count
+		case "chapter":
+			st.ChapterCount = count
+		case "category":
+			st.CategoryCount = count
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error executing query")
+	}
+
 	if !found {
 		return nil, nil
 	}
 
+	st.HistoryLimit = r.historyLimit
 	return &st, nil
 }
 

--- a/internal/database/sync_test.go
+++ b/internal/database/sync_test.go
@@ -354,11 +354,14 @@ func TestSyncRepo_Devices(t *testing.T) {
 		t.Errorf("tablet = %+v", tab)
 	}
 
-	// protocol sticks once known and empty never clears it
+	// protocol fills once and later touches never change it (SetDeviceCursor owns updates)
 	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1"}, "", "", "", "v1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1"}, "", "", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1"}, "", "", "", "v2"); err != nil {
 		t.Fatal(err)
 	}
 	devices, _ = repo.ListDevices(ctx, "key1")

--- a/internal/database/sync_test.go
+++ b/internal/database/sync_test.go
@@ -420,9 +420,10 @@ func TestSQLiteMigrationFromPreviousVersion(t *testing.T) {
 	// rewind to the previous version by dropping what the last migration added
 	previous := len(sqliteMigrations) - 1
 	for _, stmt := range []string{
-		"DROP TABLE sync_item", "DROP TABLE sync_state",
-		"ALTER TABLE sync_device DROP COLUMN last_cursor", "ALTER TABLE sync_device DROP COLUMN protocol",
-		"ALTER TABLE sync_data DROP COLUMN rendered_seq",
+		"ALTER TABLE sync_data DROP COLUMN raw_data", "ALTER TABLE sync_data DROP COLUMN raw_etag",
+		"ALTER TABLE sync_data DROP COLUMN raw_seq",
+		"ALTER TABLE sync_item DROP COLUMN modified_at",
+		"ALTER TABLE sync_status DROP COLUMN last_protocol",
 		fmt.Sprintf("PRAGMA user_version = %d", previous),
 	} {
 		if _, err := db.handler.Exec(stmt); err != nil {

--- a/internal/database/sync_test.go
+++ b/internal/database/sync_test.go
@@ -12,6 +12,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/SyncYomi/SyncYomi/internal/domain"
+	"github.com/SyncYomi/SyncYomi/internal/merge"
 	"github.com/rs/zerolog"
 )
 
@@ -229,7 +230,7 @@ func TestAPIRepo_DeleteCascadesSyncData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := syncRepo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d"}, "", "", ""); err != nil {
+	if err := syncRepo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d"}, "", "", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := apiRepo.Delete(ctx, "key1"); err != nil {
@@ -315,22 +316,22 @@ func TestSyncRepo_Devices(t *testing.T) {
 	repo := SyncRepo{log: zerolog.Nop(), db: db}
 	ctx := context.Background()
 
-	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{}, "", "", ""); err != nil {
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{}, "", "", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	if n := countRows(t, db, "sync_device", "key1"); n != 0 {
 		t.Errorf("anonymous touch created %d rows", n)
 	}
 
-	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1", Name: "Phone"}, "SYNC_SUCCESS", "success", "done"); err != nil {
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1", Name: "Phone"}, "SYNC_SUCCESS", "success", "done", ""); err != nil {
 		t.Fatal(err)
 	}
 	// second touch with no name/event keeps what we know
-	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1"}, "", "", ""); err != nil {
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1"}, "", "", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	// name-only device falls back to name as id
-	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{Name: "Tablet"}, "SYNC_STARTED", "running", ""); err != nil {
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{Name: "Tablet"}, "SYNC_STARTED", "running", "", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -351,6 +352,37 @@ func TestSyncRepo_Devices(t *testing.T) {
 	}
 	if tab := byID["Tablet"]; tab.DeviceName != "Tablet" || tab.LastStatus != "running" {
 		t.Errorf("tablet = %+v", tab)
+	}
+
+	// protocol sticks once known and empty never clears it
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1"}, "", "", "", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d1"}, "", "", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	devices, _ = repo.ListDevices(ctx, "key1")
+	for _, d := range devices {
+		if d.DeviceID == "d1" && d.Protocol != "v1" {
+			t.Errorf("protocol = %q, want v1", d.Protocol)
+		}
+	}
+
+	// forget a device
+	var id int
+	for _, d := range devices {
+		if d.DeviceID == "d1" {
+			id = d.ID
+		}
+	}
+	if err := repo.DeleteDevice(ctx, "key1", id); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.DeleteDevice(ctx, "key1", id); !stderrors.Is(err, domain.ErrNotFound) {
+		t.Errorf("second delete err = %v, want ErrNotFound", err)
+	}
+	if devices, _ = repo.ListDevices(ctx, "key1"); len(devices) != 1 {
+		t.Errorf("devices after delete = %+v", devices)
 	}
 }
 
@@ -391,6 +423,18 @@ func TestSyncRepo_Status(t *testing.T) {
 		t.Errorf("data size = %d, want 5", st.DataSize)
 	}
 
+	// protocol sticks and empty never clears it
+	if err := repo.UpsertStatus(ctx, "key1", domain.SyncStatus{LastProtocol: "v1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.UpsertStatus(ctx, "key1", domain.SyncStatus{LastStatus: "success"}); err != nil {
+		t.Fatal(err)
+	}
+	st, _ = repo.GetStatus(ctx, "key1")
+	if st.LastProtocol != "v1" {
+		t.Errorf("last_protocol = %q, want v1", st.LastProtocol)
+	}
+
 	// data only, no status row
 	insertTestAPIKey(t, db, "key2")
 	if _, err := repo.SetSyncData(ctx, "key2", []byte("ab")); err != nil {
@@ -399,6 +443,46 @@ func TestSyncRepo_Status(t *testing.T) {
 	st, err = repo.GetStatus(ctx, "key2")
 	if err != nil || st == nil || st.DataSize != 2 {
 		t.Errorf("data-only status = (%+v, %v)", st, err)
+	}
+}
+
+// GetStatus enriches the response with the server seq, item counts and the served
+// payload size (the raw v1 blob when one exists).
+func TestSyncRepo_StatusStoreFields(t *testing.T) {
+	store, db := newTestStore(t)
+	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
+	ctx := context.Background()
+
+	err := store.Tx(ctx, "key1", func(tx domain.SyncStoreTx) error {
+		if _, err := tx.Apply(ctx, write(
+			&merge.Item{Kind: merge.KindCategory, Key: "uid:1", Name: "R", Version: 1, Payload: []byte("c")},
+			&merge.Item{Kind: merge.KindManga, Key: "1|/m", Version: 1, Payload: []byte("m")},
+			&merge.Item{Kind: merge.KindChapter, Key: "1|/m\x1f/c1", ParentKey: "1|/m", Version: 1, Payload: []byte("ch")},
+			&merge.Item{Kind: merge.KindChapter, Key: "1|/m\x1f/c2", ParentKey: "1|/m", Version: 1, Payload: []byte("ch")},
+		), "A"); err != nil {
+			return err
+		}
+		if err := tx.SetRenderCache(ctx, []byte("render!"), "seq=1", 1); err != nil {
+			return err
+		}
+		return tx.SetRawBlob(ctx, []byte("raw"), "uuid=a", 1)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := repo.GetStatus(ctx, "key1")
+	if err != nil || st == nil {
+		t.Fatalf("status = (%+v, %v)", st, err)
+	}
+	if st.Seq != 1 || st.MangaCount != 1 || st.ChapterCount != 2 || st.CategoryCount != 1 {
+		t.Errorf("store fields = seq=%d m=%d ch=%d cat=%d", st.Seq, st.MangaCount, st.ChapterCount, st.CategoryCount)
+	}
+	if st.DataSize != 3 {
+		t.Errorf("data size = %d, want the raw blob's 3", st.DataSize)
+	}
+	if st.HistoryLimit != 3 {
+		t.Errorf("history limit = %d", st.HistoryLimit)
 	}
 }
 
@@ -453,7 +537,7 @@ func TestSQLiteMigrationFromPreviousVersion(t *testing.T) {
 	if err != nil || !bytes.Equal(data, []byte{1}) || *etag != "uuid=old" {
 		t.Errorf("existing data lost across migration: %v %v %v", data, etag, err)
 	}
-	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d"}, "", "", ""); err != nil {
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "d"}, "", "", "", ""); err != nil {
 		t.Errorf("new table unusable after migration: %v", err)
 	}
 	if _, err := repo.SetSyncData(ctx, "key1", []byte{2}); err != nil {
@@ -473,7 +557,7 @@ func TestSyncRepo_TimestampsAreUTC(t *testing.T) {
 	repo := SyncRepo{log: zerolog.Nop(), db: db, historyLimit: 3}
 	ctx := context.Background()
 
-	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "dev", Name: "Phone"}, "SYNC_SUCCESS", "success", ""); err != nil {
+	if err := repo.TouchDevice(ctx, "key1", domain.DeviceInfo{ID: "dev", Name: "Phone"}, "SYNC_SUCCESS", "success", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := repo.SetSyncData(ctx, "key1", []byte("abc")); err != nil {

--- a/internal/database/syncstore.go
+++ b/internal/database/syncstore.go
@@ -392,6 +392,9 @@ func (t *syncStoreTx) RawBlob(ctx context.Context) (*domain.RawBlob, error) {
 }
 
 func (t *syncStoreTx) SetRawBlob(ctx context.Context, data []byte, etag string, seq int64) error {
+	if data == nil {
+		data = []byte{} // a zero-byte upload is valid; nil violates NOT NULL columns
+	}
 	now := time.Now().UTC()
 	// the INSERT arm needs a value for the NOT NULL render columns; never touch them on conflict
 	_, err := t.repo.db.squirrel.

--- a/internal/database/syncstore.go
+++ b/internal/database/syncstore.go
@@ -18,7 +18,7 @@ import (
 const (
 	refsSep      = "\x1f"
 	sqlBatchSize = 500
-	itemColumns  = "kind, key, parent_key, name, version, deleted, refs, payload, seq, origin_device"
+	itemColumns  = "kind, key, parent_key, name, version, modified_at, deleted, refs, payload, seq, origin_device"
 )
 
 func NewSyncStore(log logger.Logger, db *DB, historyLimit int) domain.SyncStore {
@@ -172,7 +172,7 @@ func (t *syncStoreTx) queryItems(ctx context.Context, where sq.Sqlizer) ([]*merg
 			kind string
 			refs string
 		)
-		if err := rows.Scan(&kind, &it.Key, &it.ParentKey, &it.Name, &it.Version, &it.Deleted, &refs, &it.Payload, &it.Seq, &it.OriginDevice); err != nil {
+		if err := rows.Scan(&kind, &it.Key, &it.ParentKey, &it.Name, &it.Version, &it.ModifiedAt, &it.Deleted, &refs, &it.Payload, &it.Seq, &it.OriginDevice); err != nil {
 			return nil, errors.Wrap(err, "error scanning sync item")
 		}
 		it.Kind = merge.Kind(kind)
@@ -232,8 +232,8 @@ func (t *syncStoreTx) Apply(ctx context.Context, res *merge.Result, device strin
 
 const upsertItemSuffix = `ON CONFLICT (user_api_key, kind, key) DO UPDATE SET
 	parent_key = EXCLUDED.parent_key, name = EXCLUDED.name, version = EXCLUDED.version,
-	deleted = EXCLUDED.deleted, refs = EXCLUDED.refs, payload = EXCLUDED.payload,
-	seq = EXCLUDED.seq, origin_device = EXCLUDED.origin_device`
+	modified_at = EXCLUDED.modified_at, deleted = EXCLUDED.deleted, refs = EXCLUDED.refs,
+	payload = EXCLUDED.payload, seq = EXCLUDED.seq, origin_device = EXCLUDED.origin_device`
 
 // writeItems upserts rows. modernc sqlite binds thousands of parameters very slowly, so it
 // gets a prepared single-row statement; Postgres is round-trip bound and gets multi-row batches.
@@ -242,14 +242,14 @@ func (t *syncStoreTx) writeItems(ctx context.Context, items []*merge.Item, seq i
 		return nil
 	}
 	if databaseDriver != "postgres" {
-		stmt, err := t.tx.PrepareContext(ctx, `INSERT INTO sync_item (user_api_key, kind, key, parent_key, name, version, deleted, refs, payload, seq, origin_device)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) `+upsertItemSuffix)
+		stmt, err := t.tx.PrepareContext(ctx, `INSERT INTO sync_item (user_api_key, kind, key, parent_key, name, version, modified_at, deleted, refs, payload, seq, origin_device)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) `+upsertItemSuffix)
 		if err != nil {
 			return errors.Wrap(err, "error preparing sync item upsert")
 		}
 		defer stmt.Close()
 		for _, it := range items {
-			if _, err := stmt.ExecContext(ctx, t.apiKey, string(it.Kind), it.Key, it.ParentKey, it.Name, it.Version, false, strings.Join(it.Refs, refsSep), it.Payload, seq, device); err != nil {
+			if _, err := stmt.ExecContext(ctx, t.apiKey, string(it.Kind), it.Key, it.ParentKey, it.Name, it.Version, it.ModifiedAt, false, strings.Join(it.Refs, refsSep), it.Payload, seq, device); err != nil {
 				return errors.Wrap(err, "error writing sync item")
 			}
 		}
@@ -263,9 +263,9 @@ func (t *syncStoreTx) writeItems(ctx context.Context, items []*merge.Item, seq i
 		end := min(start+batch, len(items))
 		ins := t.repo.db.squirrel.
 			Insert("sync_item").
-			Columns("user_api_key", "kind", "key", "parent_key", "name", "version", "deleted", "refs", "payload", "seq", "origin_device")
+			Columns("user_api_key", "kind", "key", "parent_key", "name", "version", "modified_at", "deleted", "refs", "payload", "seq", "origin_device")
 		for _, it := range items[start:end] {
-			ins = ins.Values(t.apiKey, string(it.Kind), it.Key, it.ParentKey, it.Name, it.Version, false, strings.Join(it.Refs, refsSep), it.Payload, seq, device)
+			ins = ins.Values(t.apiKey, string(it.Kind), it.Key, it.ParentKey, it.Name, it.Version, it.ModifiedAt, false, strings.Join(it.Refs, refsSep), it.Payload, seq, device)
 		}
 		if _, err := ins.Suffix(upsertItemSuffix).RunWith(t.tx).ExecContext(ctx); err != nil {
 			return errors.Wrap(err, "error writing sync items")

--- a/internal/database/syncstore.go
+++ b/internal/database/syncstore.go
@@ -364,6 +364,62 @@ func (t *syncStoreTx) MarkRendered(ctx context.Context, seq int64) error {
 	return nil
 }
 
+func (t *syncStoreTx) RawBlob(ctx context.Context) (*domain.RawBlob, error) {
+	var (
+		rb   domain.RawBlob
+		etag sql.NullString
+		seq  sql.NullInt64
+	)
+	err := t.repo.db.squirrel.
+		Select("raw_data", "raw_etag", "raw_seq").
+		From("sync_data").
+		Where(sq.Eq{"user_api_key": t.apiKey}).
+		RunWith(t.tx).
+		QueryRowContext(ctx).
+		Scan(&rb.Data, &etag, &seq)
+	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "error reading raw blob")
+	}
+	if !seq.Valid {
+		return nil, nil
+	}
+	rb.ETag = etag.String
+	rb.Seq = seq.Int64
+	return &rb, nil
+}
+
+func (t *syncStoreTx) SetRawBlob(ctx context.Context, data []byte, etag string, seq int64) error {
+	now := time.Now().UTC()
+	// the INSERT arm needs a value for the NOT NULL render columns; never touch them on conflict
+	_, err := t.repo.db.squirrel.
+		Insert("sync_data").
+		Columns("user_api_key", "created_at", "updated_at", "data", "data_etag", "raw_data", "raw_etag", "raw_seq").
+		Values(t.apiKey, now, now, []byte{}, "", data, etag, seq).
+		Suffix("ON CONFLICT (user_api_key) DO UPDATE SET raw_data = EXCLUDED.raw_data, raw_etag = EXCLUDED.raw_etag, raw_seq = EXCLUDED.raw_seq, updated_at = EXCLUDED.updated_at").
+		RunWith(t.tx).
+		ExecContext(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error writing raw blob")
+	}
+	return t.repo.history.recordHistory(ctx, t.tx, t.apiKey, etag, data)
+}
+
+func (t *syncStoreTx) MarkRawCurrent(ctx context.Context, seq int64) error {
+	_, err := t.repo.db.squirrel.
+		Update("sync_data").
+		Set("raw_seq", seq).
+		Where(sq.Eq{"user_api_key": t.apiKey}).
+		RunWith(t.tx).
+		ExecContext(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error marking raw blob")
+	}
+	return nil
+}
+
 func (t *syncStoreTx) Clear(ctx context.Context) error {
 	_, err := t.repo.db.squirrel.
 		Delete("sync_item").

--- a/internal/database/syncstore_test.go
+++ b/internal/database/syncstore_test.go
@@ -191,6 +191,81 @@ func TestSyncStore_RenderCacheAndHistory(t *testing.T) {
 	}
 }
 
+func TestSyncStore_RawBlob(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	err := store.Tx(ctx, "key1", func(tx domain.SyncStoreTx) error {
+		raw, err := tx.RawBlob(ctx)
+		if err != nil || raw != nil {
+			t.Errorf("empty raw blob = %+v, %v", raw, err)
+		}
+		if err := tx.SetRawBlob(ctx, []byte("client bytes"), "uuid=a", 2); err != nil {
+			return err
+		}
+		raw, err = tx.RawBlob(ctx)
+		if err != nil {
+			return err
+		}
+		if raw == nil || !bytes.Equal(raw.Data, []byte("client bytes")) || raw.ETag != "uuid=a" || raw.Seq != 2 {
+			t.Errorf("raw blob = %+v", raw)
+		}
+
+		// renders and raw blobs live in the same row without clobbering each other
+		if err := tx.SetRenderCache(ctx, []byte("rendered"), "seq=3", 3); err != nil {
+			return err
+		}
+		raw, _ = tx.RawBlob(ctx)
+		if raw == nil || !bytes.Equal(raw.Data, []byte("client bytes")) || raw.Seq != 2 {
+			t.Errorf("raw blob after render = %+v", raw)
+		}
+		if err := tx.SetRawBlob(ctx, []byte("newer"), "uuid=b", 4); err != nil {
+			return err
+		}
+		rc, _ := tx.RenderCache(ctx)
+		if rc == nil || !bytes.Equal(rc.Data, []byte("rendered")) || *rc.RenderedSeq != 3 {
+			t.Errorf("render cache after raw write = %+v", rc)
+		}
+
+		if err := tx.MarkRawCurrent(ctx, 9); err != nil {
+			return err
+		}
+		raw, _ = tx.RawBlob(ctx)
+		if raw == nil || raw.Seq != 9 || !bytes.Equal(raw.Data, []byte("newer")) {
+			t.Errorf("raw blob after mark = %+v", raw)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// raw uploads are recorded in the history
+	history, err := store.history.ListHistory(ctx, "key1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 3 || history[0].ETag != "uuid=b" {
+		t.Errorf("history = %+v", history)
+	}
+
+	// a row whose raw columns are NULL (render-only key) yields nil
+	insertTestAPIKey(t, db, "key2")
+	err = store.Tx(ctx, "key2", func(tx domain.SyncStoreTx) error {
+		if err := tx.SetRenderCache(ctx, []byte("r"), "seq=1", 1); err != nil {
+			return err
+		}
+		raw, err := tx.RawBlob(ctx)
+		if err != nil || raw != nil {
+			t.Errorf("render-only raw blob = %+v, %v", raw, err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSyncStore_DeviceCursor(t *testing.T) {
 	store, _ := newTestStore(t)
 	ctx := context.Background()

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -40,6 +40,13 @@ type SyncStatus struct {
 	LastProtocol  string     `json:"last_protocol"` // "", v1 or v2
 	DataSize      int64      `json:"data_size"`
 	DataUpdatedAt *time.Time `json:"data_updated_at"`
+	// Seq is the server's change counter; a device whose cursor is behind it has
+	// that many merges still to pull.
+	Seq           int64 `json:"seq"`
+	MangaCount    int64 `json:"manga_count"`
+	ChapterCount  int64 `json:"chapter_count"`
+	CategoryCount int64 `json:"category_count"`
+	HistoryLimit  int   `json:"history_limit"`
 }
 
 // DeviceInfo is what a client optionally identifies itself with. All fields may be empty.
@@ -69,8 +76,10 @@ type SyncRepo interface {
 	GetHistoryData(ctx context.Context, apiKey string, id int) ([]byte, error)
 
 	// Empty fields never overwrite stored values. No-op when dev has no ID and no Name.
-	TouchDevice(ctx context.Context, apiKey string, dev DeviceInfo, event, status, message string) error
+	TouchDevice(ctx context.Context, apiKey string, dev DeviceInfo, event, status, message, protocol string) error
 	ListDevices(ctx context.Context, apiKey string) ([]SyncDevice, error)
+	// DeleteDevice removes a device row. ErrNotFound if id is unknown for the key.
+	DeleteDevice(ctx context.Context, apiKey string, id int) error
 
 	// Nil timestamps and empty strings never overwrite stored values.
 	UpsertStatus(ctx context.Context, apiKey string, st SyncStatus) error

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -37,6 +37,7 @@ type SyncStatus struct {
 	LastStatus    string     `json:"last_status"`
 	LastDevice    string     `json:"last_device"`
 	LastMessage   string     `json:"last_message"`
+	LastProtocol  string     `json:"last_protocol"` // "", v1 or v2
 	DataSize      int64      `json:"data_size"`
 	DataUpdatedAt *time.Time `json:"data_updated_at"`
 }
@@ -77,12 +78,21 @@ type SyncRepo interface {
 	GetStatus(ctx context.Context, apiKey string) (*SyncStatus, error)
 }
 
-// RenderCache is the last full backup rendered from the item store (served to v1 clients).
-// RenderedSeq is nil for a blob written by a pre-v2 server that has not been imported yet.
+// RenderCache is the last full backup rendered from the item store, served to v1 clients
+// only when no raw client blob is current. RenderedSeq is nil for a blob written by a
+// pre-v2 server that has not been promoted to a raw blob yet.
 type RenderCache struct {
 	Data        []byte
 	ETag        string
 	RenderedSeq *int64
+}
+
+// RawBlob is the last v1 client upload, kept byte-for-byte. It is served back verbatim
+// while Seq still equals the store's seq (no other device has written since).
+type RawBlob struct {
+	Data []byte
+	ETag string
+	Seq  int64
 }
 
 type DeviceCursor struct {
@@ -112,6 +122,12 @@ type SyncStoreTx interface {
 	SetRenderCache(ctx context.Context, data []byte, etag string, seq int64) error
 	// MarkRendered stamps the existing cache as matching seq without rewriting it.
 	MarkRendered(ctx context.Context, seq int64) error
+	// RawBlob returns the last v1 upload, or nil when none was ever stored.
+	RawBlob(ctx context.Context) (*RawBlob, error)
+	// SetRawBlob stores a v1 upload verbatim and records it in the history.
+	SetRawBlob(ctx context.Context, data []byte, etag string, seq int64) error
+	// MarkRawCurrent stamps the existing raw blob as matching seq without rewriting it.
+	MarkRawCurrent(ctx context.Context, seq int64) error
 	// Clear removes every item so the store can be rebuilt from a backup.
 	Clear(ctx context.Context) error
 	SetDeviceCursor(ctx context.Context, dc DeviceCursor) error

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -75,7 +75,8 @@ type SyncRepo interface {
 	// GetHistoryData returns the stored payload of a history entry. ErrNotFound if id is unknown.
 	GetHistoryData(ctx context.Context, apiKey string, id int) ([]byte, error)
 
-	// Empty fields never overwrite stored values. No-op when dev has no ID and no Name.
+	// Empty fields never overwrite stored values, and protocol is only filled when the row
+	// has none yet (SetDeviceCursor owns updates). No-op when dev has no ID and no Name.
 	TouchDevice(ctx context.Context, apiKey string, dev DeviceInfo, event, status, message, protocol string) error
 	ListDevices(ctx context.Context, apiKey string) ([]SyncDevice, error)
 	// DeleteDevice removes a device row. ErrNotFound if id is unknown for the key.

--- a/internal/http/sync.go
+++ b/internal/http/sync.go
@@ -118,16 +118,13 @@ func (h syncHandler) putContent(w http.ResponseWriter, r *http.Request) {
 
 	etag, err := h.syncService.PutContent(r.Context(), apiKey, deviceFromRequest(r), r.Header.Get("If-Match"), requestData)
 	if err != nil {
-		switch {
-		case errors.Is(err, sync.ErrPreconditionFailed):
+		if errors.Is(err, sync.ErrPreconditionFailed) {
 			// see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
 			w.WriteHeader(http.StatusPreconditionFailed)
-		case errors.Is(err, sync.ErrBadPayload):
-			h.encoder.StatusResponse(r.Context(), w, map[string]string{"message": "body is not a valid backup"}, http.StatusBadRequest)
-		default:
-			h.log.Error().Err(err).Msg("failed to store sync data")
-			h.encoder.StatusInternalError(w)
+			return
 		}
+		h.log.Error().Err(err).Msg("failed to store sync data")
+		h.encoder.StatusInternalError(w)
 		return
 	}
 

--- a/internal/http/sync.go
+++ b/internal/http/sync.go
@@ -60,7 +60,9 @@ func (h syncHandler) Routes(r chi.Router) {
 func (h syncHandler) AdminRoutes(r chi.Router) {
 	r.Get("/{apikey}/status", h.getStatus)
 	r.Get("/{apikey}/devices", h.listDevices)
+	r.Delete("/{apikey}/devices/{id}", h.deleteDevice)
 	r.Get("/{apikey}/history", h.listHistory)
+	r.Get("/{apikey}/history/{id}/download", h.downloadHistory)
 	r.Post("/{apikey}/history/{id}/restore", h.restoreHistory)
 }
 
@@ -91,7 +93,7 @@ func (h syncHandler) getContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.syncService.RecordContentAccess(r.Context(), apiKey, deviceFromRequest(r), false)
+	h.syncService.RecordContentAccess(r.Context(), apiKey, deviceFromRequest(r), false, sync.ProtocolV1)
 
 	if etag := r.Header.Get("If-None-Match"); etag != "" && etag == snap.ETag {
 		// see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
@@ -128,7 +130,7 @@ func (h syncHandler) putContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.syncService.RecordContentAccess(r.Context(), apiKey, deviceFromRequest(r), true)
+	h.syncService.RecordContentAccess(r.Context(), apiKey, deviceFromRequest(r), true, sync.ProtocolV1)
 
 	w.Header().Set("ETag", etag)
 	w.WriteHeader(http.StatusOK)
@@ -250,6 +252,57 @@ func (h syncHandler) listHistory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	render.JSON(w, r, history)
+}
+
+func (h syncHandler) deleteDevice(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		h.encoder.StatusResponse(r.Context(), w, map[string]string{"message": "invalid device id"}, http.StatusBadRequest)
+		return
+	}
+
+	if err := h.syncService.DeleteDevice(r.Context(), chi.URLParam(r, "apikey"), id); err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			h.encoder.StatusNotFound(r.Context(), w)
+			return
+		}
+		h.log.Error().Err(err).Msg("failed to delete device")
+		h.encoder.StatusInternalError(w)
+		return
+	}
+
+	h.encoder.NoContent(w)
+}
+
+func (h syncHandler) downloadHistory(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		h.encoder.StatusResponse(r.Context(), w, map[string]string{"message": "invalid history id"}, http.StatusBadRequest)
+		return
+	}
+
+	data, err := h.syncService.GetHistoryData(r.Context(), chi.URLParam(r, "apikey"), id)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			h.encoder.StatusNotFound(r.Context(), w)
+			return
+		}
+		h.log.Error().Err(err).Msg("failed to read sync history data")
+		h.encoder.StatusInternalError(w)
+		return
+	}
+
+	// gzipped payloads are complete .tachibk backups the apps can import directly
+	ext := ".bin"
+	if len(data) > 2 && data[0] == 0x1f && data[1] == 0x8b {
+		ext = ".tachibk"
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", `attachment; filename="sync-history-`+strconv.Itoa(id)+ext+`"`)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(data); err != nil {
+		h.log.Debug().Err(err).Msg("failed to write history download")
+	}
 }
 
 func (h syncHandler) restoreHistory(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/sync_test.go
+++ b/internal/http/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/SyncYomi/SyncYomi/internal/backup"
@@ -36,11 +37,14 @@ type mockSyncService struct {
 	reportedDevice domain.DeviceInfo
 	accessDevice   domain.DeviceInfo
 	accessWrite    bool
+	accessProto    string
 	accessCalls    int
 
 	adminErr    error
 	history     []domain.SyncHistoryEntry
+	historyData []byte
 	devices     []domain.SyncDevice
+	deletedID   int
 	status      *domain.SyncStatus
 	restoreEtag *string
 }
@@ -77,9 +81,10 @@ func (m *mockSyncService) ReportSyncEvent(ctx context.Context, apiKey string, ev
 	return m.reportEventErr
 }
 
-func (m *mockSyncService) RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool) {
+func (m *mockSyncService) RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool, protocol string) {
 	m.accessDevice = dev
 	m.accessWrite = write
+	m.accessProto = protocol
 	m.accessCalls++
 }
 
@@ -99,6 +104,24 @@ func (m *mockSyncService) RestoreHistory(ctx context.Context, apiKey string, id 
 
 func (m *mockSyncService) ListDevices(ctx context.Context, apiKey string) ([]domain.SyncDevice, error) {
 	return m.devices, m.adminErr
+}
+
+func (m *mockSyncService) DeleteDevice(ctx context.Context, apiKey string, id int) error {
+	if m.adminErr != nil {
+		return m.adminErr
+	}
+	m.deletedID = id
+	return nil
+}
+
+func (m *mockSyncService) GetHistoryData(ctx context.Context, apiKey string, id int) ([]byte, error) {
+	if m.adminErr != nil {
+		return nil, m.adminErr
+	}
+	if m.historyData == nil {
+		return nil, domain.ErrNotFound
+	}
+	return m.historyData, nil
 }
 
 func (m *mockSyncService) GetStatus(ctx context.Context, apiKey string) (*domain.SyncStatus, error) {
@@ -350,6 +373,51 @@ func TestSyncHandler_adminRoutes(t *testing.T) {
 			newAdmin(mock).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 			if rec.Code != http.StatusOK || !bytes.HasPrefix(bytes.TrimSpace(rec.Body.Bytes()), []byte("[")) {
 				t.Errorf("%s = %v %q", path, rec.Code, rec.Body.String())
+			}
+		}
+	})
+
+	t.Run("delete device", func(t *testing.T) {
+		for _, tc := range []struct {
+			path string
+			mock *mockSyncService
+			want int
+		}{
+			{"/key1/devices/3", &mockSyncService{}, http.StatusNoContent},
+			{"/key1/devices/abc", &mockSyncService{}, http.StatusBadRequest},
+			{"/key1/devices/9", &mockSyncService{adminErr: domain.ErrNotFound}, http.StatusNotFound},
+		} {
+			rec := httptest.NewRecorder()
+			newAdmin(tc.mock).ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, tc.path, nil))
+			if rec.Code != tc.want {
+				t.Errorf("%s = %v, want %v", tc.path, rec.Code, tc.want)
+			}
+		}
+	})
+
+	t.Run("download history", func(t *testing.T) {
+		gz := gzipBytes(t, []byte("backup"))
+		for _, tc := range []struct {
+			path     string
+			mock     *mockSyncService
+			want     int
+			wantName string
+		}{
+			{"/key1/history/1/download", &mockSyncService{historyData: gz}, http.StatusOK, `filename="sync-history-1.tachibk"`},
+			{"/key1/history/1/download", &mockSyncService{historyData: []byte("raw")}, http.StatusOK, `filename="sync-history-1.bin"`},
+			{"/key1/history/2/download", &mockSyncService{}, http.StatusNotFound, ""},
+			{"/key1/history/abc/download", &mockSyncService{}, http.StatusBadRequest, ""},
+		} {
+			rec := httptest.NewRecorder()
+			newAdmin(tc.mock).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if rec.Code != tc.want {
+				t.Errorf("%s = %v, want %v", tc.path, rec.Code, tc.want)
+			}
+			if tc.wantName != "" && !strings.Contains(rec.Header().Get("Content-Disposition"), tc.wantName) {
+				t.Errorf("%s disposition = %q, want %q", tc.path, rec.Header().Get("Content-Disposition"), tc.wantName)
+			}
+			if tc.want == http.StatusOK && !bytes.Equal(rec.Body.Bytes(), tc.mock.historyData) {
+				t.Errorf("%s body mismatch", tc.path)
 			}
 		}
 	})

--- a/internal/http/sync_test.go
+++ b/internal/http/sync_test.go
@@ -174,9 +174,8 @@ func TestSyncHandler_putContent(t *testing.T) {
 		wantStatus int
 		wantETag   string
 	}{
-		{name: "put returns new etag", mock: &mockSyncService{putEtag: "seq=2"}, wantStatus: http.StatusOK, wantETag: "seq=2"},
-		{name: "412 on etag mismatch", ifMatch: "seq=1", mock: &mockSyncService{putErr: sync.ErrPreconditionFailed}, wantStatus: http.StatusPreconditionFailed},
-		{name: "400 on undecodable payload", mock: &mockSyncService{putErr: sync.ErrBadPayload}, wantStatus: http.StatusBadRequest},
+		{name: "put returns new etag", mock: &mockSyncService{putEtag: "uuid=abc"}, wantStatus: http.StatusOK, wantETag: "uuid=abc"},
+		{name: "412 on etag mismatch", ifMatch: "uuid=stale", mock: &mockSyncService{putErr: sync.ErrPreconditionFailed}, wantStatus: http.StatusPreconditionFailed},
 		{name: "500 on error", mock: &mockSyncService{putErr: errors.New("db")}, wantStatus: http.StatusInternalServerError},
 	}
 	for _, tt := range tests {

--- a/internal/http/syncv2.go
+++ b/internal/http/syncv2.go
@@ -89,7 +89,7 @@ func (h syncHandler) merge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.syncService.RecordContentAccess(ctx, r.Header.Get("X-API-Token"), dev, true)
+	h.syncService.RecordContentAccess(ctx, r.Header.Get("X-API-Token"), dev, true, sync.ProtocolV2)
 
 	w.Header().Set(headerCursor, strconv.FormatInt(resp.Cursor, 10))
 	w.Header().Set(headerChanged, strconv.FormatBool(resp.Changed))
@@ -122,7 +122,7 @@ func (h syncHandler) snapshot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.syncService.RecordContentAccess(r.Context(), r.Header.Get("X-API-Token"), deviceFromRequest(r), false)
+	h.syncService.RecordContentAccess(r.Context(), r.Header.Get("X-API-Token"), deviceFromRequest(r), false, sync.ProtocolV2)
 
 	w.Header().Set(headerCursor, strconv.FormatInt(snap.Cursor, 10))
 	w.Header().Set("ETag", snap.ETag)

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -138,4 +138,3 @@ func (m *merger) returnItem(cur *Item) {
 	m.res.ReturnKeys[cur.Kind] = append(m.res.ReturnKeys[cur.Kind], cur.Key)
 	m.res.ChangedForClient = true
 }
-

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -5,7 +5,8 @@ import "bytes"
 // Merge applies the client's items to the store state and decides what to write and what to send back. Absence never means deletion: only explicit tombstones delete.
 //
 // Rules (same as TachiyomiSY's client merge, minus the absence inference):
-//   - versioned kinds (manga, chapter, category): higher version wins, tie -> server keeps
+//   - versioned kinds (manga, chapter, category): higher version wins; on a version tie the
+//     newer ModifiedAt wins, and only a full tie keeps the server copy
 //   - section kinds: client wins on conflict
 //   - client-only -> insert; server-only -> not touched here, returned by the delta
 func Merge(store Store, req Request) *Result {
@@ -75,6 +76,8 @@ func (m *merger) category(it *Item) {
 		m.write(it)
 	case it.Version < cur.Version:
 		m.returnItem(cur)
+	default:
+		m.tiebreak(it, cur)
 	}
 }
 
@@ -102,9 +105,22 @@ func (m *merger) versioned(it *Item) {
 		m.write(it)
 	case it.Version < cur.Version:
 		m.returnItem(cur)
+	default:
+		m.tiebreak(it, cur)
 	}
-	// equal version: server keeps its copy; differences without a version bump are
-	// not synced (the client's SQL triggers bump the version for anything that matters)
+}
+
+// tiebreak resolves an equal-version conflict by ModifiedAt. Clients whose SQL triggers
+// bump Version never land here with a real difference, but clients that leave Version at
+// zero (v1-era builds) rely on this to propagate anything after their first upload.
+func (m *merger) tiebreak(it, cur *Item) {
+	switch {
+	case it.ModifiedAt > cur.ModifiedAt:
+		m.write(it)
+	case it.ModifiedAt < cur.ModifiedAt:
+		m.returnItem(cur)
+	}
+	// full tie: server keeps its copy
 }
 
 func (m *merger) section(it *Item) {
@@ -123,19 +139,3 @@ func (m *merger) returnItem(cur *Item) {
 	m.res.ChangedForClient = true
 }
 
-func sameRefs(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	seen := make(map[string]int, len(a))
-	for _, x := range a {
-		seen[x]++
-	}
-	for _, x := range b {
-		if seen[x] == 0 {
-			return false
-		}
-		seen[x]--
-	}
-	return true
-}

--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -122,6 +122,46 @@ func TestHigherVersionWinsTieServerKeeps(t *testing.T) {
 	}
 }
 
+// Clients that never bump Version (v1-era builds leave it at 0) rely on ModifiedAt to
+// break the tie; otherwise their first upload would win forever.
+func TestEqualVersionModifiedAtTiebreak(t *testing.T) {
+	s := newMemStore()
+	old := &Item{Kind: KindManga, Key: "1|/m", Version: 0, ModifiedAt: 100, Payload: []byte("old")}
+	s.merge("A", old)
+
+	// same version, newer timestamp: client wins
+	newer := &Item{Kind: KindManga, Key: "1|/m", Version: 0, ModifiedAt: 200, Payload: []byte("new")}
+	res := s.merge("B", newer)
+	if len(res.Writes) != 1 || string(s.Get(KindManga, "1|/m").Payload) != "new" {
+		t.Errorf("newer ModifiedAt must win on a version tie: %+v", res)
+	}
+
+	// same version, older timestamp: server wins and the item is returned
+	res = s.merge("A", old)
+	if len(res.Writes) != 0 || !res.ChangedForClient || len(res.ReturnKeys[KindManga]) != 1 {
+		t.Errorf("older ModifiedAt must lose and be returned: %+v", res)
+	}
+
+	// full tie stays a no-op
+	res = s.merge("A", newer)
+	if len(res.Writes) != 0 || res.ChangedForClient {
+		t.Errorf("full tie must be a no-op: %+v", res)
+	}
+
+	// a higher version still beats a newer timestamp
+	res = s.merge("A", &Item{Kind: KindManga, Key: "1|/m", Version: 1, ModifiedAt: 50, Payload: []byte("v1")})
+	if len(res.Writes) != 1 || string(s.Get(KindManga, "1|/m").Payload) != "v1" {
+		t.Errorf("version outranks ModifiedAt: %+v", res)
+	}
+
+	// same rule for categories
+	s.merge("A", &Item{Kind: KindCategory, Key: "uid:1", Name: "Read", Version: 0, ModifiedAt: 100, Payload: []byte("a")})
+	res = s.merge("B", &Item{Kind: KindCategory, Key: "uid:1", Name: "Read", Version: 0, ModifiedAt: 200, Payload: []byte("b")})
+	if len(res.Writes) != 1 || string(s.Get(KindCategory, "uid:1").Payload) != "b" {
+		t.Errorf("category tiebreak: %+v", res)
+	}
+}
+
 func TestUnfavoriteTravelsAsVersionBump(t *testing.T) {
 	s := newMemStore()
 	s.merge("A", manga("1|/m", 5, "fav"))

--- a/internal/merge/types.go
+++ b/internal/merge/types.go
@@ -35,9 +35,13 @@ type Item struct {
 	ParentKey string // chapter -> manga key, source_pref -> source key
 	Name      string // category display name, used for the uid-less fallback match
 	Version   int64
-	Deleted   bool     // category tombstone
-	Refs      []string // manga -> category keys
-	Payload   []byte
+	// ModifiedAt breaks equal-version ties (clients that never bump Version would
+	// otherwise be stuck at "first write wins forever"). Extracted by the adapter so the
+	// merge itself still never inspects payloads.
+	ModifiedAt int64
+	Deleted    bool     // category tombstone
+	Refs       []string // manga -> category keys
+	Payload    []byte
 
 	// set by the store
 	Seq          int64

--- a/internal/sync/merge.go
+++ b/internal/sync/merge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SyncYomi/SyncYomi/internal/backup/pb"
 	"github.com/SyncYomi/SyncYomi/internal/domain"
 	"github.com/SyncYomi/SyncYomi/internal/merge"
+	"github.com/google/uuid"
 )
 
 const (
@@ -52,6 +53,11 @@ type Snapshot struct {
 }
 
 func etagFor(seq int64) string { return "seq=" + strconv.FormatInt(seq, 10) }
+
+// rawETag mints an etag for a raw v1 upload. The wire format ("uuid=<uuid4>", unquoted)
+// matches pre-1.3 servers: v1 clients echo the value verbatim, and the prefix keeps raw
+// etags distinguishable from the render cache's "seq=<n>".
+func rawETag() string { return "uuid=" + uuid.NewString() }
 
 // keyLocks serialises merges per API key inside this process; the database transaction
 // covers other instances.
@@ -165,13 +171,62 @@ func (s *service) Snapshot(ctx context.Context, apiKey string, cursor int64) (*S
 	return snap, err
 }
 
-// GetContent serves v1 clients the rendered backup. ErrNoData when nothing was ever stored.
+// GetContent serves v1 clients their own uploaded bytes verbatim while no other device
+// has written since; only then does it fall back to the rendered backup. v1 clients merge
+// remote and local state themselves, so fidelity of the stored bytes matters more than
+// server-side merging. ErrNoData when nothing was ever stored.
 func (s *service) GetContent(ctx context.Context, apiKey string) (*Snapshot, error) {
-	return s.Snapshot(ctx, apiKey, 0)
+	defer s.locks.lock(apiKey)()
+
+	var snap *Snapshot
+	err := s.store.Tx(ctx, apiKey, func(tx domain.SyncStoreTx) error {
+		if _, err := s.ensureMigrated(ctx, tx); err != nil {
+			return err
+		}
+		raw, err := tx.RawBlob(ctx)
+		if err != nil {
+			return err
+		}
+		if raw != nil && raw.Seq == tx.Seq() {
+			snap = &Snapshot{Data: raw.Data, ETag: raw.ETag, Cursor: tx.Seq()}
+			return nil
+		}
+		if !tx.Exists() {
+			return ErrNoData
+		}
+		rc, err := s.currentRender(ctx, tx)
+		if err != nil {
+			return err
+		}
+		snap = &Snapshot{Data: rc.Data, ETag: rc.ETag, Cursor: tx.Seq()}
+		return nil
+	})
+	return snap, err
 }
 
-// PutContent is the v1 upload: the blob is merged like a full v2 request from the "legacy"
-// device. ErrPreconditionFailed when ifMatch is set and differs from the current ETag.
+// v1ETag is the etag a v1 GET would return right now, "" when there is no data yet.
+func (s *service) v1ETag(ctx context.Context, tx domain.SyncStoreTx) (string, error) {
+	raw, err := tx.RawBlob(ctx)
+	if err != nil {
+		return "", err
+	}
+	if raw != nil && raw.Seq == tx.Seq() {
+		return raw.ETag, nil
+	}
+	if !tx.Exists() {
+		return "", nil
+	}
+	rc, err := s.currentRender(ctx, tx)
+	if err != nil {
+		return "", err
+	}
+	return rc.ETag, nil
+}
+
+// PutContent is the v1 upload: the bytes are stored verbatim as the authoritative blob
+// (v1 clients merge remote and local themselves, so the upload is already the merged
+// state) and imported into the item store on a best-effort basis for v2 devices.
+// ErrPreconditionFailed when ifMatch is set and differs from the current ETag.
 func (s *service) PutContent(ctx context.Context, apiKey string, dev domain.DeviceInfo, ifMatch string, data []byte) (string, error) {
 	s.warnLegacy(apiKey, dev)
 	defer s.locks.lock(apiKey)()
@@ -182,43 +237,37 @@ func (s *service) PutContent(ctx context.Context, apiKey string, dev domain.Devi
 			return err
 		}
 		if ifMatch != "" {
-			rc, err := tx.RenderCache(ctx)
+			cur, err := s.v1ETag(ctx, tx)
 			if err != nil {
 				return err
 			}
-			if rc == nil || rc.ETag != ifMatch {
+			if cur == "" || cur != ifMatch {
 				return ErrPreconditionFailed
 			}
 		}
 
-		b, err := backup.Decode(data)
-		if err != nil {
-			return fmt.Errorf("%w: %v", ErrBadPayload, err)
-		}
 		device := dev.Key()
 		if device == "" {
 			device = deviceLegacy
 		}
-		res, err := s.mergeBackup(ctx, tx, b, device, nil)
-		if err != nil {
-			return err
-		}
-		startSeq := tx.Seq()
-		newSeq, err := tx.Apply(ctx, res, device)
-		if err != nil {
-			return err
-		}
-		if newSeq != startSeq {
-			if err := s.refreshRenderCache(ctx, tx, false, nil); err != nil {
+		// import failures must not fail the request: 1.1.14 accepted arbitrary bytes, and
+		// the raw blob below is what v1 devices actually exchange
+		if b, err := backup.Decode(data); err != nil {
+			s.log.Error().Err(err).Msg("v1 payload does not decode, storing it verbatim without importing")
+		} else if res, err := s.mergeBackup(ctx, tx, b, device, nil); err != nil {
+			if !errors.Is(err, ErrBadPayload) {
 				return err
 			}
-		}
-		rc, err := s.currentRender(ctx, tx)
-		if err != nil {
+			s.log.Error().Err(err).Msg("v1 payload could not be split, storing it verbatim without importing")
+		} else if _, err := tx.Apply(ctx, res, device); err != nil {
 			return err
 		}
-		etag = rc.ETag
-		return tx.SetDeviceCursor(ctx, domain.DeviceCursor{Device: dev, Cursor: newSeq, Protocol: ProtocolV1})
+
+		etag = rawETag()
+		if err := tx.SetRawBlob(ctx, data, etag, tx.Seq()); err != nil {
+			return err
+		}
+		return tx.SetDeviceCursor(ctx, domain.DeviceCursor{Device: domain.DeviceInfo{ID: device, Name: dev.Name}, Cursor: tx.Seq(), Protocol: ProtocolV1})
 	})
 	return etag, err
 }
@@ -248,11 +297,10 @@ func (s *service) RestoreHistory(ctx context.Context, apiKey string, id int) (*s
 		if _, err := tx.Apply(ctx, res, deviceRestore); err != nil {
 			return err
 		}
-		if err := s.refreshRenderCache(ctx, tx, false, nil); err != nil {
-			return err
-		}
-		etag = etagFor(tx.Seq())
-		return nil
+		// the restored payload becomes the raw blob so v1 devices get it byte-for-byte;
+		// the render refreshes lazily on the next v2 read
+		etag = rawETag()
+		return tx.SetRawBlob(ctx, data, etag, tx.Seq())
 	})
 	if err != nil {
 		return nil, err
@@ -260,23 +308,34 @@ func (s *service) RestoreHistory(ctx context.Context, apiKey string, id int) (*s
 	return &etag, nil
 }
 
-// ensureMigrated imports a pre-v2 blob into the item store on first contact. Returns true
-// when an import happened in this call.
+// ensureMigrated imports a pre-v2 blob into the item store on first contact, first
+// promoting it to the raw blob (original bytes and etag) so v1 clients keep receiving it
+// verbatim even when it cannot be decoded. Returns true when an import happened in this call.
 func (s *service) ensureMigrated(ctx context.Context, tx domain.SyncStoreTx) (bool, error) {
 	if tx.Exists() {
 		return false, nil
 	}
-	rc, err := tx.RenderCache(ctx)
+	raw, err := tx.RawBlob(ctx)
 	if err != nil {
 		return false, err
 	}
-	if rc == nil || rc.RenderedSeq != nil {
-		return false, nil
+	if raw == nil {
+		rc, err := tx.RenderCache(ctx)
+		if err != nil {
+			return false, err
+		}
+		if rc == nil || rc.RenderedSeq != nil {
+			return false, nil
+		}
+		if err := tx.SetRawBlob(ctx, rc.Data, rc.ETag, tx.Seq()); err != nil {
+			return false, err
+		}
+		raw = &domain.RawBlob{Data: rc.Data, ETag: rc.ETag, Seq: tx.Seq()}
 	}
 
-	b, err := backup.Decode(rc.Data)
+	b, err := backup.Decode(raw.Data)
 	if err != nil {
-		// keep serving the raw blob to v1 clients; the store starts empty
+		// the raw blob keeps being served verbatim to v1 clients; the store stays empty
 		s.log.Error().Err(err).Msg("legacy sync payload cannot be decoded, starting with an empty item store")
 		return false, nil
 	}
@@ -288,7 +347,7 @@ func (s *service) ensureMigrated(ctx context.Context, tx domain.SyncStoreTx) (bo
 	if err != nil {
 		return false, err
 	}
-	if err := tx.MarkRendered(ctx, seq); err != nil {
+	if err := tx.MarkRawCurrent(ctx, seq); err != nil {
 		return false, err
 	}
 	s.log.Info().Int("manga", len(b.BackupManga)).Int("categories", len(b.BackupCategories)).Msg("imported legacy sync payload into the item store")

--- a/internal/sync/merge.go
+++ b/internal/sync/merge.go
@@ -287,6 +287,7 @@ func (s *service) RestoreHistory(ctx context.Context, apiKey string, id int) (*s
 
 	var etag string
 	err = s.store.Tx(ctx, apiKey, func(tx domain.SyncStoreTx) error {
+		startSeq := tx.Seq()
 		if err := tx.Clear(ctx); err != nil {
 			return err
 		}
@@ -294,8 +295,16 @@ func (s *service) RestoreHistory(ctx context.Context, apiKey string, id int) (*s
 		if err != nil {
 			return err
 		}
-		if _, err := tx.Apply(ctx, res, deviceRestore); err != nil {
+		newSeq, err := tx.Apply(ctx, res, deviceRestore)
+		if err != nil {
 			return err
+		}
+		if newSeq == startSeq {
+			// an empty backup writes nothing, so the seq cannot signal the change; rewrite
+			// the render in place or v2 readers keep the pre-restore content
+			if err := s.refreshRenderCache(ctx, tx, false, nil); err != nil {
+				return err
+			}
 		}
 		// the restored payload becomes the raw blob so v1 devices get it byte-for-byte;
 		// the render refreshes lazily on the next v2 read

--- a/internal/sync/merge_test.go
+++ b/internal/sync/merge_test.go
@@ -451,6 +451,44 @@ func TestRestore_EmptyBackupRefreshesRender(t *testing.T) {
 	}
 }
 
+// A v1 phone shows up twice — an anonymous upload row and a named event row — unless the
+// event tags the named row with the protocol.
+func TestV1_EventTagsDeviceProtocol(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	blob, _ := backup.Encode(&pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(1, "/m", 1, true)}})
+	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "", blob); err != nil {
+		t.Fatal(err)
+	}
+	// the handler records the access (and with it the protocol) after every v1 PUT
+	svc.RecordContentAccess(ctx, "key1", domain.DeviceInfo{}, true, ProtocolV1)
+	if err := svc.ReportSyncEvent(ctx, "key1", "SYNC_SUCCESS", domain.DeviceInfo{Name: "My Phone"}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	devices, err := svc.ListDevices(ctx, "key1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]string{}
+	for _, d := range devices {
+		byID[d.DeviceID] = d.Protocol
+	}
+	if byID["My Phone"] != "v1" {
+		t.Errorf("event device protocol = %q, want v1 (devices: %+v)", byID["My Phone"], devices)
+	}
+
+	// a later v2 sync from the same device overrides the tag
+	sync2(t, svc, "My Phone", 0, true, &pb.Backup{})
+	devices, _ = svc.ListDevices(ctx, "key1")
+	for _, d := range devices {
+		if d.DeviceID == "My Phone" && d.Protocol != "v2" {
+			t.Errorf("protocol after v2 sync = %q", d.Protocol)
+		}
+	}
+}
+
 func TestV1_IfMatch(t *testing.T) {
 	svc, _ := newTestService(t)
 	ctx := context.Background()

--- a/internal/sync/merge_test.go
+++ b/internal/sync/merge_test.go
@@ -1,7 +1,9 @@
 package sync
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/SyncYomi/SyncYomi/internal/backup"
@@ -209,66 +211,225 @@ func TestMerge_LegacyImportAndV1(t *testing.T) {
 	legacy := &pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(1, "/legacy", 3, true, chapterOf("/c", 1, true))}, BackupCategories: []*pb.BackupCategory{{Name: "Old", Uid: 5}}}
 	raw, _ := backup.Encode(legacy)
 	repo := database.NewSyncRepo(logger.Mock(), db, 3)
-	if _, err := repo.SetSyncData(ctx, "key1", raw); err != nil {
+	legacyETag, err := repo.SetSyncData(ctx, "key1", raw)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	// v1 GET keeps working and serves it
+	// v1 GET serves the legacy blob byte-for-byte under its original etag
 	snap, err := svc.GetContent(ctx, "key1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, _ := backup.Decode(snap.Data)
-	if len(got.BackupManga) != 1 || got.BackupManga[0].Url != "/legacy" {
-		t.Fatalf("v1 get after import = %v", got.BackupManga)
+	if !bytes.Equal(snap.Data, raw) {
+		t.Fatal("v1 get did not echo the legacy blob verbatim")
+	}
+	if snap.ETag != *legacyETag {
+		t.Errorf("etag after promotion = %q, want the original %q", snap.ETag, *legacyETag)
 	}
 
-	// a v2 client starting fresh gets the imported data and is told to do a full sync next time
+	// a v2 client starting fresh gets the imported data
 	resp := sync2(t, svc, "N", 0, false, &pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(2, "/new", 1, true)}})
 	if urls(resp.Backup)["/legacy"] == nil {
 		t.Errorf("imported manga missing from v2 response: %v", resp.Backup.BackupManga)
 	}
 
-	// a v1 client uploads a client-merged blob: merged, not replaced, and If-Match is honoured
-	v1blob, _ := backup.Encode(&pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(3, "/v1only", 1, true)}})
+	// the v2 write made the raw blob stale: v1 GET falls back to a render of everything
+	snap, err = svc.GetContent(ctx, "key1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(snap.ETag, "seq=") {
+		t.Errorf("render fallback etag = %q", snap.ETag)
+	}
+	got, _ := backup.Decode(snap.Data)
+	if len(got.BackupManga) != 2 {
+		t.Fatalf("render fallback manga = %v", got.BackupManga)
+	}
+
+	// a v1 client uploads its client-merged state: If-Match honoured, then echoed verbatim
+	v1blob, _ := backup.Encode(&pb.Backup{BackupManga: []*pb.BackupManga{
+		mangaOf(1, "/legacy", 3, true, chapterOf("/c", 1, true)), mangaOf(2, "/new", 1, true), mangaOf(3, "/v1only", 1, true),
+	}})
 	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{Name: "Old phone"}, "uuid=stale", v1blob); err != ErrPreconditionFailed {
 		t.Errorf("stale If-Match err = %v", err)
 	}
-	snap, _ = svc.GetContent(ctx, "key1")
 	etag, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{Name: "Old phone"}, snap.ETag, v1blob)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !strings.HasPrefix(etag, "uuid=") {
+		t.Errorf("v1 put etag = %q", etag)
 	}
 	snap, _ = svc.GetContent(ctx, "key1")
 	if snap.ETag != etag {
 		t.Errorf("etag after put %q != get %q", etag, snap.ETag)
 	}
-	got, _ = backup.Decode(snap.Data)
-	if len(got.BackupManga) != 3 {
-		t.Errorf("v1 put replaced instead of merged: %d manga", len(got.BackupManga))
-	}
-	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "", []byte("garbage")); err == nil {
-		t.Error("garbage accepted")
+	if !bytes.Equal(snap.Data, v1blob) {
+		t.Error("v1 get did not echo the uploaded blob verbatim")
 	}
 
-	// history captured the renders; restoring the first one rebuilds the store
+	// the upload was also imported for v2 devices
+	resp = sync2(t, svc, "N", resp.Cursor, false, &pb.Backup{})
+	if urls(resp.Backup)["/v1only"] == nil {
+		t.Errorf("v1 upload missing from v2 delta: %v", resp.Backup.BackupManga)
+	}
+
+	// garbage is stored and echoed like 1.1.14, never imported
+	gtag, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "", []byte("garbage"))
+	if err != nil {
+		t.Fatalf("garbage rejected: %v", err)
+	}
+	snap, _ = svc.GetContent(ctx, "key1")
+	if string(snap.Data) != "garbage" || snap.ETag != gtag {
+		t.Errorf("garbage echo = %q etag %q want %q", snap.Data, snap.ETag, gtag)
+	}
+	v2snap, err := svc.Snapshot(ctx, "key1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v2got, _ := backup.Decode(v2snap.Data); len(v2got.BackupManga) != 3 {
+		t.Errorf("garbage leaked into the item store: %v", v2got.BackupManga)
+	}
+
+	// history captured the uploads; restoring one serves those bytes verbatim again
 	history, _ := svc.ListHistory(ctx, "key1")
 	if len(history) < 2 {
 		t.Fatalf("history = %v", history)
 	}
-	oldest := history[len(history)-1]
-	if _, err := svc.RestoreHistory(ctx, "key1", oldest.ID); err != nil {
+	var restoreID int
+	for _, h := range history {
+		if h.ETag == etag {
+			restoreID = h.ID
+		}
+	}
+	if restoreID == 0 {
+		t.Fatalf("v1 upload not in history: %v", history)
+	}
+	if _, err := svc.RestoreHistory(ctx, "key1", restoreID); err != nil {
 		t.Fatal(err)
 	}
 	snap, _ = svc.GetContent(ctx, "key1")
-	got, _ = backup.Decode(snap.Data)
-	if len(got.BackupManga) >= 3 {
-		t.Errorf("restore did not rebuild the store: %d manga", len(got.BackupManga))
+	if !bytes.Equal(snap.Data, v1blob) {
+		t.Error("restore did not serve the restored payload verbatim")
 	}
 	// devices with an old cursor get everything again
 	resp = sync2(t, svc, "N", resp.Cursor, false, &pb.Backup{})
 	if !resp.Changed || len(resp.Backup.BackupManga) == 0 {
 		t.Errorf("after restore delta = changed=%v %d manga", resp.Changed, len(resp.Backup.BackupManga))
+	}
+}
+
+// An undecodable pre-v2 blob must keep being served verbatim forever and never be
+// replaced by a render, even as v1 and v2 writes continue on the same key.
+func TestV1_UndecodableLegacyPreserved(t *testing.T) {
+	svc, db := newTestService(t)
+	ctx := context.Background()
+
+	garbage := []byte{0xde, 0xad, 0xbe, 0xef, 0x01}
+	repo := database.NewSyncRepo(logger.Mock(), db, 3)
+	gtag, err := repo.SetSyncData(ctx, "key1", garbage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := svc.GetContent(ctx, "key1")
+	if err != nil {
+		t.Fatalf("v1 get on undecodable legacy blob: %v", err)
+	}
+	if !bytes.Equal(snap.Data, garbage) || snap.ETag != *gtag {
+		t.Fatal("undecodable legacy blob not served verbatim")
+	}
+
+	// v2 has nothing: the store is empty, but the blob must survive that
+	if _, err := svc.Snapshot(ctx, "key1", 0); err != ErrNoData {
+		t.Errorf("v2 snapshot on empty store err = %v, want ErrNoData", err)
+	}
+	snap, err = svc.GetContent(ctx, "key1")
+	if err != nil || !bytes.Equal(snap.Data, garbage) {
+		t.Fatalf("legacy blob lost after v2 snapshot: %v", err)
+	}
+
+	// a valid v1 upload takes over without having destroyed anything in between
+	blob, _ := backup.Encode(&pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(1, "/m", 1, true)}})
+	etag, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "", blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap, _ = svc.GetContent(ctx, "key1")
+	if !bytes.Equal(snap.Data, blob) || snap.ETag != etag {
+		t.Error("valid upload after undecodable legacy not echoed")
+	}
+}
+
+// A v1 upload must not disturb what v2 clients see beyond its imported items, and a
+// v2 write makes the raw blob stale until the next v1 upload.
+func TestV1_V2Interplay(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	sync2(t, svc, "A", 0, true, &pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(1, "/a", 1, true)}})
+	before, err := svc.Snapshot(ctx, "key1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// a v1 upload that adds nothing new: the v2 snapshot must be untouched
+	blob, _ := backup.Encode(&pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(1, "/a", 1, true)}})
+	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "", blob); err != nil {
+		t.Fatal(err)
+	}
+	after, err := svc.Snapshot(ctx, "key1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before.Data, after.Data) || before.ETag != after.ETag {
+		t.Error("no-op v1 upload changed the v2 snapshot")
+	}
+
+	// the raw blob is current, so v1 gets the echo
+	snap, _ := svc.GetContent(ctx, "key1")
+	if !bytes.Equal(snap.Data, blob) {
+		t.Error("v1 get did not echo while raw is current")
+	}
+
+	// a v2 write invalidates it: v1 falls back to the render until the next upload
+	sync2(t, svc, "B", 0, true, &pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(2, "/b", 1, true)}})
+	snap, _ = svc.GetContent(ctx, "key1")
+	if !strings.HasPrefix(snap.ETag, "seq=") {
+		t.Errorf("etag after v2 write = %q, want render fallback", snap.ETag)
+	}
+	if got, _ := backup.Decode(snap.Data); len(got.BackupManga) != 2 {
+		t.Errorf("render fallback = %v", got.BackupManga)
+	}
+	etag2, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, snap.ETag, blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap, _ = svc.GetContent(ctx, "key1")
+	if !bytes.Equal(snap.Data, blob) || snap.ETag != etag2 {
+		t.Error("echo did not resume after v1 upload")
+	}
+}
+
+func TestV1_IfMatch(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	blob, _ := backup.Encode(&pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(1, "/m", 1, true)}})
+
+	// If-Match against an empty key fails like 1.1.14 did
+	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "uuid=anything", blob); err != ErrPreconditionFailed {
+		t.Errorf("If-Match on empty key err = %v", err)
+	}
+	etag, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "", blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "uuid=stale", blob); err != ErrPreconditionFailed {
+		t.Errorf("stale If-Match err = %v", err)
+	}
+	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, etag, blob); err != nil {
+		t.Errorf("matching If-Match err = %v", err)
 	}
 }
 

--- a/internal/sync/merge_test.go
+++ b/internal/sync/merge_test.go
@@ -412,6 +412,45 @@ func TestV1_V2Interplay(t *testing.T) {
 	}
 }
 
+// Restoring an entry that decodes to an empty backup writes no items and cannot bump seq;
+// the render must still be rewritten or v2 readers keep the pre-restore content.
+func TestRestore_EmptyBackupRefreshesRender(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	empty, _ := backup.Encode(&pb.Backup{})
+	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "", empty); err != nil {
+		t.Fatal(err)
+	}
+	full, _ := backup.Encode(&pb.Backup{BackupManga: []*pb.BackupManga{mangaOf(1, "/m", 1, true)}})
+	if _, err := svc.PutContent(ctx, "key1", domain.DeviceInfo{}, "", full); err != nil {
+		t.Fatal(err)
+	}
+	if snap, err := svc.Snapshot(ctx, "key1", 0); err != nil {
+		t.Fatal(err)
+	} else if got, _ := backup.Decode(snap.Data); len(got.BackupManga) != 1 {
+		t.Fatalf("pre-restore snapshot = %v", got.BackupManga)
+	}
+
+	history, _ := svc.ListHistory(ctx, "key1")
+	emptyID := history[len(history)-1].ID
+	if _, err := svc.RestoreHistory(ctx, "key1", emptyID); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := svc.Snapshot(ctx, "key1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := backup.Decode(snap.Data); len(got.BackupManga) != 0 {
+		t.Errorf("v2 snapshot after empty restore still has %v", got.BackupManga)
+	}
+	v1snap, _ := svc.GetContent(ctx, "key1")
+	if !bytes.Equal(v1snap.Data, empty) {
+		t.Error("v1 get did not serve the restored empty payload")
+	}
+}
+
 func TestV1_IfMatch(t *testing.T) {
 	svc, _ := newTestService(t)
 	ctx := context.Background()

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -106,7 +106,15 @@ func (s *service) ReportSyncEvent(ctx context.Context, apiKey string, event stri
 
 	now := time.Now().UTC()
 	status := statusFromEvent(ev)
-	if err := s.repo.TouchDevice(ctx, apiKey, dev, event, status, detailMessage, ""); err != nil {
+	// v1 requests carry no device identity, so the anonymous upload and the named event
+	// rows for the same phone cannot be joined directly. When the key's last sync was v1,
+	// tag the event's device row (only if it has no protocol yet) so the UI can show one
+	// device instead of a named row plus the "legacy" aggregate.
+	protocolHint := ""
+	if st, err := s.repo.GetStatus(ctx, apiKey); err == nil && st != nil && st.LastProtocol == ProtocolV1 {
+		protocolHint = ProtocolV1
+	}
+	if err := s.repo.TouchDevice(ctx, apiKey, dev, event, status, detailMessage, protocolHint); err != nil {
 		s.log.Warn().Err(err).Msg("failed to record device")
 	}
 	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -25,12 +25,17 @@ type Service interface {
 
 	// ReportSyncEvent persists a device-reported sync event and sends it to the notification service.
 	ReportSyncEvent(ctx context.Context, apiKey string, event string, dev domain.DeviceInfo, detailMessage string) error
-	// RecordContentAccess updates device/status bookkeeping after a successful GET or PUT of the content. Errors are logged, not returned.
-	RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool)
+	// RecordContentAccess updates device/status bookkeeping after a successful GET or PUT of the
+	// content, tagging the key and device with the protocol used. Errors are logged, not returned.
+	RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool, protocol string)
 
 	ListHistory(ctx context.Context, apiKey string) ([]domain.SyncHistoryEntry, error)
 	RestoreHistory(ctx context.Context, apiKey string, id int) (*string, error)
+	// GetHistoryData returns the stored payload of a history entry. domain.ErrNotFound if id is unknown.
+	GetHistoryData(ctx context.Context, apiKey string, id int) ([]byte, error)
 	ListDevices(ctx context.Context, apiKey string) ([]domain.SyncDevice, error)
+	// DeleteDevice removes a device row. domain.ErrNotFound if id is unknown for the key.
+	DeleteDevice(ctx context.Context, apiKey string, id int) error
 	GetStatus(ctx context.Context, apiKey string) (*domain.SyncStatus, error)
 }
 
@@ -62,21 +67,33 @@ func (s *service) ListDevices(ctx context.Context, apiKey string) ([]domain.Sync
 	return s.repo.ListDevices(ctx, apiKey)
 }
 
+func (s *service) DeleteDevice(ctx context.Context, apiKey string, id int) error {
+	return s.repo.DeleteDevice(ctx, apiKey, id)
+}
+
+func (s *service) GetHistoryData(ctx context.Context, apiKey string, id int) ([]byte, error) {
+	return s.repo.GetHistoryData(ctx, apiKey, id)
+}
+
 func (s *service) GetStatus(ctx context.Context, apiKey string) (*domain.SyncStatus, error) {
 	return s.repo.GetStatus(ctx, apiKey)
 }
 
-func (s *service) RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool) {
-	if err := s.repo.TouchDevice(ctx, apiKey, dev, "", "", ""); err != nil {
+func (s *service) RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool, protocol string) {
+	if err := s.repo.TouchDevice(ctx, apiKey, dev, "", "", "", protocol); err != nil {
 		s.log.Warn().Err(err).Msg("failed to record device")
 	}
 
+	// reads record the protocol too: a v1-only fleet must be flagged even if it never PUTs
 	if !write {
+		if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{LastProtocol: protocol}); err != nil {
+			s.log.Warn().Err(err).Msg("failed to record sync status")
+		}
 		return
 	}
 
 	now := time.Now().UTC()
-	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{LastSyncedAt: &now, LastDevice: dev.Name}); err != nil {
+	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{LastSyncedAt: &now, LastDevice: dev.Name, LastProtocol: protocol}); err != nil {
 		s.log.Warn().Err(err).Msg("failed to record sync status")
 	}
 }
@@ -89,7 +106,7 @@ func (s *service) ReportSyncEvent(ctx context.Context, apiKey string, event stri
 
 	now := time.Now().UTC()
 	status := statusFromEvent(ev)
-	if err := s.repo.TouchDevice(ctx, apiKey, dev, event, status, detailMessage); err != nil {
+	if err := s.repo.TouchDevice(ctx, apiKey, dev, event, status, detailMessage, ""); err != nil {
 		s.log.Warn().Err(err).Msg("failed to record device")
 	}
 	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -97,6 +97,10 @@ export const APIClient = {
       appClient.Post<{ etag: string }>(
         `api/sync/admin/${key}/history/${id}/restore`,
       ),
+    deleteDevice: (key: string, id: number) =>
+      appClient.Delete(`api/sync/admin/${key}/devices/${id}`),
+    downloadHistoryUrl: (key: string, id: number) =>
+      `${baseUrl()}api/sync/admin/${key}/history/${id}/download`,
   },
   config: {
     get: () => appClient.Get<Config>("api/config"),

--- a/web/src/components/settings/SyncKeyDetails.test.ts
+++ b/web/src/components/settings/SyncKeyDetails.test.ts
@@ -97,7 +97,7 @@ describe("SyncKeyDetails", () => {
 
     const historyRows = tables[2].findAll("tbody tr");
     expect(historyRows).toHaveLength(2);
-    expect(historyRows[0].text()).toContain("current");
+    expect(historyRows[0].text()).toContain("Current");
     expect(historyRows[0].text()).toContain("server merge");
     expect(historyRows[0].text()).not.toContain("Restore");
     expect(historyRows[1].text()).toContain("4.8 MB");

--- a/web/src/components/settings/SyncKeyDetails.test.ts
+++ b/web/src/components/settings/SyncKeyDetails.test.ts
@@ -10,6 +10,10 @@ const { sync } = vi.hoisted(() => ({
     devices: vi.fn(),
     history: vi.fn(),
     restore: vi.fn(),
+    deleteDevice: vi.fn(),
+    downloadHistoryUrl: vi.fn(
+      (key: string, id: number) => `/api/sync/admin/${key}/history/${id}/download`,
+    ),
   },
 }));
 
@@ -31,6 +35,7 @@ const mountDetails = async () => {
 };
 
 describe("SyncKeyDetails", () => {
+  // the status payload of a server that predates protocol/seq/count fields
   it("renders devices and history as table rows", async () => {
     sync.status.mockResolvedValue({
       last_synced_at: "2026-08-30T15:04:27Z",
@@ -77,18 +82,94 @@ describe("SyncKeyDetails", () => {
     const tables = wrapper.findAll("table");
     expect(tables).toHaveLength(3);
 
+    // the status predates last_protocol, but a v1 device still triggers the banner
+    expect(wrapper.text()).toContain("Legacy sync protocol in use");
+    // no library data from an old server: no extra rows
+    expect(tables[0].text()).not.toContain("Library");
+
     const deviceRows = tables[1].findAll("tbody tr");
     expect(deviceRows).toHaveLength(2);
     expect(deviceRows[0].text()).toContain("Phone");
     expect(deviceRows[1].text()).toContain("dev-b");
     expect(deviceRows[1].text()).toContain("legacy");
+    // seq unknown: lag cannot be computed
+    expect(deviceRows[0].text()).not.toContain("up to date");
 
     const historyRows = tables[2].findAll("tbody tr");
     expect(historyRows).toHaveLength(2);
     expect(historyRows[0].text()).toContain("current");
-    expect(historyRows[0].find("button").exists()).toBe(false);
+    expect(historyRows[0].text()).toContain("server merge");
+    expect(historyRows[0].text()).not.toContain("Restore");
     expect(historyRows[1].text()).toContain("4.8 MB");
-    expect(historyRows[1].find("button").text()).toContain("Restore");
+    expect(historyRows[1].text()).toContain("Restore");
+  });
+
+  it("flags a v1 key and shows lag and library stats", async () => {
+    sync.status.mockResolvedValue({
+      last_synced_at: "2026-08-30T15:04:27Z",
+      last_event_at: null,
+      last_event: "",
+      last_status: "",
+      last_device: "",
+      last_message: "",
+      last_protocol: "v1",
+      data_size: 1024,
+      data_updated_at: "2026-08-30T15:04:27Z",
+      seq: 12,
+      manga_count: 42,
+      chapter_count: 800,
+      category_count: 3,
+      history_limit: 10,
+    });
+    sync.devices.mockResolvedValue([
+      {
+        id: 3,
+        device_id: "legacy",
+        device_name: "",
+        last_seen: "2026-08-30T15:04:27Z",
+        last_event: "",
+        last_status: "",
+        last_message: "",
+        protocol: "v1",
+        cursor: 12,
+        created_at: "2026-08-30T15:00:00Z",
+      },
+      {
+        id: 4,
+        device_id: "dev-c",
+        device_name: "Tablet",
+        last_seen: "2026-08-30T15:00:00Z",
+        last_event: "",
+        last_status: "",
+        last_message: "",
+        protocol: "v2",
+        cursor: 9,
+        created_at: "2026-08-30T15:00:00Z",
+      },
+    ]);
+    sync.history.mockResolvedValue([
+      { id: 11, etag: "uuid=abc", size: 1024, created_at: "2026-08-30T15:04:27Z" },
+    ]);
+
+    const wrapper = await mountDetails();
+    expect(wrapper.text()).toContain("Legacy sync protocol in use");
+
+    const tables = wrapper.findAll("table");
+    expect(tables[0].text()).toContain("v1 · legacy");
+    expect(tables[0].text()).toContain("42 manga");
+    expect(tables[0].text()).toContain("800 chapters");
+    expect(tables[0].text()).toContain("3 categories");
+    expect(wrapper.text()).toContain("Keeps the last 10 payloads.");
+
+    const deviceRows = tables[1].findAll("tbody tr");
+    expect(deviceRows[0].text()).toContain("Legacy device");
+    expect(deviceRows[0].text()).toContain("up to date");
+    expect(deviceRows[1].text()).toContain("3 behind");
+
+    const historyRows = tables[2].findAll("tbody tr");
+    expect(historyRows[0].text()).toContain("device upload");
+    const download = historyRows[0].find("a[href]");
+    expect(download.attributes("href")).toContain("/history/11/download");
   });
 
   it("shows empty states", async () => {
@@ -100,5 +181,6 @@ describe("SyncKeyDetails", () => {
     expect(wrapper.text()).toContain("No sync recorded yet.");
     expect(wrapper.text()).toContain("No devices seen yet.");
     expect(wrapper.text()).toContain("No previous payloads kept.");
+    expect(wrapper.text()).not.toContain("Legacy sync protocol in use");
   });
 });

--- a/web/src/components/settings/SyncKeyDetails.test.ts
+++ b/web/src/components/settings/SyncKeyDetails.test.ts
@@ -172,6 +172,61 @@ describe("SyncKeyDetails", () => {
     expect(download.attributes("href")).toContain("/history/11/download");
   });
 
+  it("collapses the legacy aggregate into a tagged device", async () => {
+    sync.status.mockResolvedValue({
+      last_synced_at: "2026-09-02T01:13:29Z",
+      last_event_at: "2026-09-02T01:13:29Z",
+      last_event: "SYNC_SUCCESS",
+      last_status: "success",
+      last_device: "My Phone",
+      last_message: "",
+      last_protocol: "v1",
+      data_size: 1024,
+      data_updated_at: "2026-09-02T01:13:29Z",
+      seq: 4,
+      manga_count: 359,
+      chapter_count: 42137,
+      category_count: 11,
+      history_limit: 10,
+    });
+    sync.devices.mockResolvedValue([
+      {
+        id: 1,
+        device_id: "My Phone",
+        device_name: "My Phone",
+        last_seen: "2026-09-02T01:13:29Z",
+        last_event: "SYNC_SUCCESS",
+        last_status: "success",
+        last_message: "",
+        protocol: "v1",
+        cursor: 0,
+        created_at: "2026-09-02T01:00:00Z",
+      },
+      {
+        id: 2,
+        device_id: "legacy",
+        device_name: "",
+        last_seen: "2026-09-02T01:13:29Z",
+        last_event: "",
+        last_status: "",
+        last_message: "",
+        protocol: "v1",
+        cursor: 4,
+        created_at: "2026-09-02T01:00:00Z",
+      },
+    ]);
+    sync.history.mockResolvedValue([]);
+
+    const wrapper = await mountDetails();
+    const deviceRows = wrapper.findAll("table")[1].findAll("tbody tr");
+    expect(deviceRows).toHaveLength(1);
+    expect(deviceRows[0].text()).toContain("My Phone");
+    expect(deviceRows[0].text()).not.toContain("Legacy device");
+    // the tagged row's cursor is not real; no lag state is invented for it
+    expect(deviceRows[0].find('[aria-label="Up to date"]').exists()).toBe(false);
+    expect(deviceRows[0].text()).not.toContain("behind");
+  });
+
   it("shows empty states", async () => {
     sync.status.mockRejectedValue(new Error("404"));
     sync.devices.mockResolvedValue([]);

--- a/web/src/components/settings/SyncKeyDetails.test.ts
+++ b/web/src/components/settings/SyncKeyDetails.test.ts
@@ -93,7 +93,7 @@ describe("SyncKeyDetails", () => {
     expect(deviceRows[1].text()).toContain("dev-b");
     expect(deviceRows[1].text()).toContain("legacy");
     // seq unknown: lag cannot be computed
-    expect(deviceRows[0].text()).not.toContain("up to date");
+    expect(deviceRows[0].find('[aria-label="Up to date"]').exists()).toBe(false);
 
     const historyRows = tables[2].findAll("tbody tr");
     expect(historyRows).toHaveLength(2);
@@ -163,7 +163,7 @@ describe("SyncKeyDetails", () => {
 
     const deviceRows = tables[1].findAll("tbody tr");
     expect(deviceRows[0].text()).toContain("Legacy device");
-    expect(deviceRows[0].text()).toContain("up to date");
+    expect(deviceRows[0].find('[aria-label="Up to date"]').exists()).toBe(true);
     expect(deviceRows[1].text()).toContain("3 behind");
 
     const historyRows = tables[2].findAll("tbody tr");

--- a/web/src/components/settings/SyncKeyDetails.vue
+++ b/web/src/components/settings/SyncKeyDetails.vue
@@ -195,23 +195,27 @@
               </v-chip>
             </template>
             <template #[`item.actions`]="{ item, index }">
-              <v-btn
-                icon="mdi-download-outline"
-                size="x-small"
-                variant="text"
-                title="Download this payload as a backup file."
-                :href="APIClient.sync.downloadHistoryUrl(props.apiKey, item.id)"
-              />
-              <v-chip v-if="index === 0" size="x-small">current</v-chip>
-              <v-btn
-                v-else
-                size="small"
-                variant="text"
-                :loading="restore.isPending.value && restoringId === item.id"
-                @click="askRestore(item.id)"
-              >
-                Restore
-              </v-btn>
+              <div class="d-flex align-center justify-end">
+                <v-btn
+                  icon="mdi-download-outline"
+                  size="x-small"
+                  variant="text"
+                  title="Download this payload as a backup file."
+                  :href="APIClient.sync.downloadHistoryUrl(props.apiKey, item.id)"
+                />
+                <v-btn v-if="index === 0" size="small" variant="text" disabled>
+                  Current
+                </v-btn>
+                <v-btn
+                  v-else
+                  size="small"
+                  variant="text"
+                  :loading="restore.isPending.value && restoringId === item.id"
+                  @click="askRestore(item.id)"
+                >
+                  Restore
+                </v-btn>
+              </div>
             </template>
           </v-data-table>
         </v-card>

--- a/web/src/components/settings/SyncKeyDetails.vue
+++ b/web/src/components/settings/SyncKeyDetails.vue
@@ -106,35 +106,35 @@
               </v-chip>
             </template>
             <template #[`item.protocol`]="{ item }">
-              <v-chip
-                v-if="item.protocol === 'v1'"
-                color="warning"
-                size="x-small"
-                title="This device uses the legacy sync protocol. Update the app to sync faster and more reliably."
-              >
-                legacy
-              </v-chip>
-              <span v-else-if="item.protocol">{{ item.protocol }}</span>
-              <span v-else>—</span>
-              <v-chip
-                v-if="deviceLag(item) === 0"
-                size="x-small"
-                variant="tonal"
-                color="success"
-                class="ml-1"
-              >
-                up to date
-              </v-chip>
-              <v-chip
-                v-else-if="deviceLag(item) !== null"
-                size="x-small"
-                variant="tonal"
-                color="warning"
-                class="ml-1"
-                title="Merges on the server this device has not pulled yet."
-              >
-                {{ deviceLag(item) }} behind
-              </v-chip>
+              <div class="d-flex align-center ga-1 text-no-wrap">
+                <v-chip
+                  v-if="item.protocol === 'v1'"
+                  color="warning"
+                  size="x-small"
+                  title="This device uses the legacy sync protocol. Update the app to sync faster and more reliably."
+                >
+                  legacy
+                </v-chip>
+                <span v-else-if="item.protocol">{{ item.protocol }}</span>
+                <span v-else>—</span>
+                <v-icon
+                  v-if="deviceLag(item) === 0"
+                  icon="mdi-check-circle-outline"
+                  size="x-small"
+                  color="success"
+                  title="Up to date"
+                  aria-label="Up to date"
+                />
+                <v-chip
+                  v-else-if="deviceLag(item) !== null"
+                  size="x-small"
+                  variant="tonal"
+                  color="warning"
+                  title="Merges on the server this device has not pulled yet."
+                >
+                  {{ deviceLag(item) }} behind
+                </v-chip>
+              </div>
             </template>
             <template #[`item.last_event`]="{ item }">
               {{ item.last_event || "—" }}

--- a/web/src/components/settings/SyncKeyDetails.vue
+++ b/web/src/components/settings/SyncKeyDetails.vue
@@ -1,5 +1,14 @@
 <template>
   <div class="pa-4">
+    <v-alert
+      v-if="hasLegacyDevice"
+      type="warning"
+      variant="tonal"
+      density="compact"
+      class="mb-4"
+      title="Legacy sync protocol in use"
+      text="A device on this key syncs with the deprecated v1 protocol. It keeps working, but update the app once it supports v2 for faster, finer-grained sync."
+    />
     <v-row>
       <v-col cols="12" md="4">
         <v-card variant="outlined" title="Status">
@@ -32,6 +41,30 @@
                 <th class="text-left text-no-wrap">Message</th>
                 <td>{{ status.last_message }}</td>
               </tr>
+              <tr v-if="status.last_protocol">
+                <th class="text-left text-no-wrap">Protocol</th>
+                <td>
+                  <v-chip
+                    v-if="status.last_protocol === 'v1'"
+                    color="warning"
+                    size="x-small"
+                    title="This key was last synced with the deprecated v1 protocol."
+                  >
+                    v1 · legacy
+                  </v-chip>
+                  <v-chip v-else size="x-small" variant="tonal">
+                    {{ status.last_protocol }}
+                  </v-chip>
+                </td>
+              </tr>
+              <tr v-if="hasLibraryStats">
+                <th class="text-left text-no-wrap">Library</th>
+                <td>
+                  {{ status.manga_count ?? 0 }} manga ·
+                  {{ status.chapter_count ?? 0 }} chapters ·
+                  {{ status.category_count ?? 0 }} categories
+                </td>
+              </tr>
               <tr>
                 <th class="text-left text-no-wrap">Stored payload</th>
                 <td :title="relativeDate(status.data_updated_at)">
@@ -60,13 +93,14 @@
             no-data-text="No devices seen yet. Devices appear once they report sync events."
           >
             <template #[`item.name`]="{ item }">
-              {{ item.device_name || item.device_id }}
+              <span :title="deviceTooltip(item)">{{ deviceName(item) }}</span>
             </template>
             <template #[`item.last_status`]="{ item }">
               <v-chip
                 v-if="item.last_status"
                 :color="statusColor(item.last_status)"
                 size="x-small"
+                :title="item.last_message || undefined"
               >
                 {{ item.last_status }}
               </v-chip>
@@ -80,7 +114,27 @@
               >
                 legacy
               </v-chip>
-              <span v-else>{{ item.protocol || "—" }}</span>
+              <span v-else-if="item.protocol">{{ item.protocol }}</span>
+              <span v-else>—</span>
+              <v-chip
+                v-if="deviceLag(item) === 0"
+                size="x-small"
+                variant="tonal"
+                color="success"
+                class="ml-1"
+              >
+                up to date
+              </v-chip>
+              <v-chip
+                v-else-if="deviceLag(item) !== null"
+                size="x-small"
+                variant="tonal"
+                color="warning"
+                class="ml-1"
+                title="Merges on the server this device has not pulled yet."
+              >
+                {{ deviceLag(item) }} behind
+              </v-chip>
             </template>
             <template #[`item.last_event`]="{ item }">
               {{ item.last_event || "—" }}
@@ -90,12 +144,22 @@
                 simplifyDate(item.last_seen)
               }}</span>
             </template>
+            <template #[`item.actions`]="{ item }">
+              <v-btn
+                icon="mdi-delete-outline"
+                size="x-small"
+                variant="text"
+                title="Forget this device. It reappears if it syncs again."
+                :loading="forgetDevice.isPending.value && forgettingId === item.id"
+                @click="askForget(item.id)"
+              />
+            </template>
           </v-data-table>
         </v-card>
       </v-col>
 
       <v-col cols="12">
-        <v-card variant="outlined" title="History">
+        <v-card variant="outlined" title="History" :subtitle="historySubtitle">
           <v-data-table
             :headers="historyHeaders"
             :items="history"
@@ -117,7 +181,27 @@
             <template #[`item.etag`]="{ item }">
               <code>{{ item.etag }}</code>
             </template>
+            <template #[`item.origin`]="{ item }">
+              <v-chip
+                size="x-small"
+                variant="tonal"
+                :title="
+                  historyOrigin(item) === 'device upload'
+                    ? 'Uploaded by a device, byte-for-byte.'
+                    : 'Assembled by the server from merged changes.'
+                "
+              >
+                {{ historyOrigin(item) }}
+              </v-chip>
+            </template>
             <template #[`item.actions`]="{ item, index }">
+              <v-btn
+                icon="mdi-download-outline"
+                size="x-small"
+                variant="text"
+                title="Download this payload as a backup file."
+                :href="APIClient.sync.downloadHistoryUrl(props.apiKey, item.id)"
+              />
               <v-chip v-if="index === 0" size="x-small">current</v-chip>
               <v-btn
                 v-else
@@ -141,6 +225,13 @@
       @confirmed="confirmedRestore"
       @canceled="restoringId = null"
     />
+    <confirmation-modal
+      ref="forgetConfirmationModal"
+      title="Forget device"
+      message="Remove this device from the list? Its synced data stays; the device reappears if it syncs again."
+      @confirmed="confirmedForget"
+      @canceled="forgettingId = null"
+    />
   </div>
 </template>
 
@@ -162,6 +253,10 @@ const restoreConfirmationModal = ref<InstanceType<
   typeof ConfirmationModal
 > | null>(null);
 const restoringId = ref<number | null>(null);
+const forgetConfirmationModal = ref<InstanceType<
+  typeof ConfirmationModal
+> | null>(null);
+const forgettingId = ref<number | null>(null);
 
 const statusQuery = useQuery({
   queryKey: ["syncStatus", props.apiKey],
@@ -191,6 +286,7 @@ const restore = useMutation({
   onSuccess: () => {
     queryClient.invalidateQueries({ queryKey: ["syncStatus", props.apiKey] });
     queryClient.invalidateQueries({ queryKey: ["syncHistory", props.apiKey] });
+    queryClient.invalidateQueries({ queryKey: ["syncDevices", props.apiKey] });
     emit("restored");
   },
   onError: (error: Error) => emit("error", error.message),
@@ -210,18 +306,88 @@ const confirmedRestore = () => {
   }
 };
 
+const forgetDevice = useMutation({
+  mutationFn: (id: number) => APIClient.sync.deleteDevice(props.apiKey, id),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ["syncDevices", props.apiKey] });
+  },
+  onError: (error: Error) => emit("error", error.message),
+  onSettled: () => {
+    forgettingId.value = null;
+  },
+});
+
+const askForget = (id: number) => {
+  forgettingId.value = id;
+  forgetConfirmationModal.value?.showModal();
+};
+
+const confirmedForget = () => {
+  if (forgettingId.value !== null) {
+    forgetDevice.mutate(forgettingId.value);
+  }
+};
+
+// warn when the last write was v1 or any known device still speaks v1
+const hasLegacyDevice = computed(
+  () =>
+    status.value?.last_protocol === "v1" ||
+    devices.value.some((d) => d.protocol === "v1"),
+);
+
+const hasLibraryStats = computed(() => {
+  const s = status.value;
+  return !!s && ((s.manga_count ?? 0) > 0 || (s.category_count ?? 0) > 0);
+});
+
+const historySubtitle = computed(() => {
+  const limit = status.value?.history_limit;
+  return limit ? `Keeps the last ${limit} payloads.` : undefined;
+});
+
+// v1 uploads carry no device identity; the server records them under "legacy"
+const deviceName = (d: SyncDevice) => {
+  if (d.device_name) return d.device_name;
+  if (d.device_id === "legacy") return "Legacy device";
+  return d.device_id;
+};
+
+const deviceTooltip = (d: SyncDevice) => {
+  const parts = [];
+  if (d.device_id === "legacy") {
+    parts.push(
+      "One or more v1 clients that don't identify themselves share this row.",
+    );
+  } else if (d.device_name && d.device_id !== d.device_name) {
+    parts.push(`ID: ${d.device_id}`);
+  }
+  if (d.created_at) parts.push(`First seen ${simplifyDate(d.created_at)}`);
+  return parts.join(" · ") || undefined;
+};
+
+// merges on the server the device has not pulled; null when unknowable
+const deviceLag = (d: SyncDevice) => {
+  const seq = status.value?.seq;
+  if (seq === undefined || !d.protocol) return null;
+  return Math.max(0, seq - d.cursor);
+};
+
+const historyOrigin = (h: SyncHistoryEntry) =>
+  h.etag.startsWith("uuid=") ? "device upload" : "server merge";
+
 const deviceHeaders = [
   { title: "Device", key: "name", sortable: false },
   { title: "Status", key: "last_status" },
-  { title: "Protocol", key: "protocol" },
+  { title: "Sync", key: "protocol", sortable: false },
   { title: "Last event", key: "last_event" },
   { title: "Last seen", key: "last_seen" },
-  { title: "Cursor", key: "cursor", align: "end" as const },
+  { title: "", key: "actions", sortable: false, align: "end" as const },
 ];
 
 const historyHeaders = [
   { title: "Created", key: "created_at", sortable: false },
   { title: "Size", key: "size", sortable: false },
+  { title: "Origin", key: "origin", sortable: false },
   { title: "ETag", key: "etag", sortable: false },
   { title: "", key: "actions", sortable: false, align: "end" as const },
 ];

--- a/web/src/components/settings/SyncKeyDetails.vue
+++ b/web/src/components/settings/SyncKeyDetails.vue
@@ -83,7 +83,7 @@
         <v-card variant="outlined" title="Devices">
           <v-data-table
             :headers="deviceHeaders"
-            :items="devices"
+            :items="visibleDevices"
             :loading="devicesQuery.isLoading.value"
             :sort-by="[{ key: 'last_seen', order: 'desc' }]"
             :items-per-page="-1"
@@ -335,6 +335,17 @@ const hasLegacyDevice = computed(
     devices.value.some((d) => d.protocol === "v1"),
 );
 
+// "legacy" aggregates anonymous v1 uploads; once a named row is tagged v1 it represents
+// that traffic, so showing the aggregate too would list one phone twice
+const visibleDevices = computed(() => {
+  const named = devices.value.some(
+    (d) => d.device_id !== "legacy" && d.protocol === "v1",
+  );
+  return named
+    ? devices.value.filter((d) => d.device_id !== "legacy")
+    : devices.value;
+});
+
 const hasLibraryStats = computed(() => {
   const s = status.value;
   return !!s && ((s.manga_count ?? 0) > 0 || (s.category_count ?? 0) > 0);
@@ -365,10 +376,13 @@ const deviceTooltip = (d: SyncDevice) => {
   return parts.join(" · ") || undefined;
 };
 
-// merges on the server the device has not pulled; null when unknowable
+// merges on the server the device has not pulled; null when unknowable. A v1 row with
+// cursor 0 was tagged from events only — its real cursor lives on the anonymous upload.
 const deviceLag = (d: SyncDevice) => {
   const seq = status.value?.seq;
   if (seq === undefined || !d.protocol) return null;
+  if (d.protocol === "v1" && d.cursor === 0 && d.device_id !== "legacy")
+    return null;
   return Math.max(0, seq - d.cursor);
 };
 

--- a/web/src/types/API.d.ts
+++ b/web/src/types/API.d.ts
@@ -12,8 +12,15 @@ interface SyncStatus {
   last_status: "" | "running" | "success" | "error" | "cancelled";
   last_device: string;
   last_message: string;
+  // fields below are absent on servers predating them; render fallbacks
+  last_protocol?: "" | "v1" | "v2";
   data_size: number;
   data_updated_at: string | null;
+  seq?: number;
+  manga_count?: number;
+  chapter_count?: number;
+  category_count?: number;
+  history_limit?: number;
 }
 
 interface SyncDevice {


### PR DESCRIPTION
Restores 1.1.x blob-echo behaviour on the v1 sync endpoints so legacy clients (Komikku, TachiyomiSY) work again until the upstream v2 client PR merges, breaks equal-version merge ties with last_modified_at, adds a server-only v1 e2e suite with its own CI workflow, and surfaces v1 deprecation, sync lag and library stats in the web UI.