### PR TITLE
ci(e2e): drop dispatch input defaults so repo variables apply

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,12 +5,11 @@ on:
     - cron: "0 16 * * *"
   workflow_dispatch:
     inputs:
+      # no defaults: a blank input falls through to the E2E_*_REF repo variable
       tachiyomi_ref:
-        description: "TachiyomiSY ref to build"
-        default: "feat/syncyomi-v2"
+        description: "TachiyomiSY ref to build (blank = repo variable)"
       suwayomi_ref:
-        description: "Suwayomi-Server ref to build"
-        default: "feat/syncyomi-v2"
+        description: "Suwayomi-Server ref to build (blank = repo variable)"
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Drops the `feat/syncyomi-v2` defaults from the e2e `workflow_dispatch` inputs. GitHub fills a blank input with its default, so `inputs.*_ref` always won over the `E2E_TACHIYOMI_REF` and `E2E_SUWAYOMI_REF` repo variables on a manual run. A blank input now falls through to the variable, and a filled input still overrides it for a one-off build against another ref. Scheduled and pull request runs are unchanged.
