### PR TITLE
fix(sync): answer v1 requests without waiting for the bookkeeping writes

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -59,7 +59,18 @@ The same view shows which devices have synced with the key, when they were last 
 - Large libraries: a v1 upload is answered in well under a second whatever its size. In
   1.3–1.5 the import ran inside the request and a library of a few thousand manga exceeded
   the 10 s timeout of Komikku's sync client on every sync (#225). Each import now logs
-  `imported v1 upload into the item store` with its duration.
+  `imported v1 upload into the item store` with its duration (`took`) and how long it
+  held the database write lock (`locked`).
+- Requests no longer wait for their own bookkeeping. Every v1 `GET`/`PUT` and every
+  `POST /api/sync/event` updates the device and status rows; those writes queue behind the
+  write lock, which a large import holds for seconds, and used to run before the response.
+  They now run in the background, in order, and are dropped with a warning if they cannot
+  get the lock within 5 s. The web UI may show a device's last activity a few seconds late.
+- The background import merges the upload against a read snapshot and only takes the write
+  lock to store the result, so a v1 fleet's own `PUT`s wait far less behind it.
+- SQLite logs `SQLite refused WAL mode` when the filesystem cannot provide WAL (network
+  mounts, some Docker volume drivers). Without WAL every read waits for the running import;
+  keep the database on a local filesystem.
 - The HTTP server has timeouts: 15 s to send request headers, 10 min per request, 2 min
   for an idle keep-alive connection. The event stream is exempt.
 - Schema: `sync_data` gains `raw_data`/`raw_etag`/`raw_seq`/`raw_pending`, `sync_item`

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -57,6 +57,8 @@ Env vars:
 - `flows/` — the few Maestro UI flows that can't be replaced by adb.
 - `scenarios/` — the tests (`//go:build e2e`), one fresh server per test,
   emulators booted once per run.
+- `scenarios/v1/` — the v1 protocol suite (`//go:build e2e_v1`): server only, no
+  emulators, run with `scripts/run-e2e-v1.sh`. Its clients carry the forks' 10 s timeout.
 - Failures dump logcat, prefs, server snapshot/devices into
   `artifacts/<run>/<test>/`.
 
@@ -78,6 +80,19 @@ Env vars:
 | S13 device tombstone (UI) | Deleting a category on-device sends `X-Sync-Deleted-Categories`; no resurrection |
 | S14 Suwayomi core convergence | Suwayomi applies read progress, category rename/membership and tombstones, and pushes its own edits back |
 | S15 cross-platform deep sync | Android UI edits (read + category assign) reach Suwayomi; Suwayomi edits come back to Android |
+
+v1 suite (`scenarios/v1/`, server only):
+
+| Test | What it proves |
+|---|---|
+| V1 echo round trip | A v1 push comes back byte-identical with a `uuid=` etag; If-None-Match 304s; gzip uploads land |
+| V1 two devices | Two v1 devices exchange state through the blob; If-Match rejects a stale upload |
+| V1 legacy upgrade | A pre-1.3 `sync_data` row is served verbatim after upgrade, decodable or not |
+| V1 mixed fleet | A v2 write invalidates the echo (v1 gets a render with both sides); the next v1 upload resumes it |
+| V1 garbage tolerated | An undecodable upload is accepted and echoed, and a later valid one replaces it |
+| V1 large library | 3600 manga × 60 chapters: PUT, GET, second PUT and the post-v2 render all answer inside 10 s |
+| V1 responsive while locked | With the write lock held for 8 s, v1 GET/304/event answer within 2 s; their bookkeeping lands afterwards |
+| V1 responsive during import | While a v2 full merge imports the pending upload, v1 GET and event answer within 3 s every round |
 
 Device-originated *drag* reorder is a known gap: the drag handle has no
 accessibility label, so Maestro can't grip it; S11 covers reorder propagation

--- a/e2e/harness/assert.go
+++ b/e2e/harness/assert.go
@@ -45,6 +45,30 @@ func (s *SyncServer) Devices(ctx context.Context) ([]domain.SyncDevice, error) {
 	return devices, err
 }
 
+// Status fetches the per-key sync status the web UI shows.
+func (s *SyncServer) Status(ctx context.Context) (*domain.SyncStatus, error) {
+	var st domain.SyncStatus
+	if err := s.AdminGet(ctx, "/api/sync/admin/"+s.APIKey+"/status", &st); err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+// WaitFor polls cond every 200 ms until it returns true or timeout passes.
+func WaitFor(ctx context.Context, timeout time.Duration, cond func() bool) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if cond() {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("condition not met within %s", timeout)
+}
+
 // WaitForDeviceSync polls until some device's last_seen passes since and its
 // cursor is positive — i.e. a v2 merge completed after the trigger.
 func (s *SyncServer) WaitForDeviceSync(ctx context.Context, since time.Time, timeout time.Duration) (*domain.SyncDevice, error) {

--- a/e2e/harness/sqlite.go
+++ b/e2e/harness/sqlite.go
@@ -1,0 +1,37 @@
+package harness
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// HoldWriteLock takes the server's SQLite write lock (BEGIN IMMEDIATE, the same mode the
+// server uses for its own transactions) and keeps it until release is called or d elapses.
+// It stands in for a long import: every write on the server queues behind it, and reads
+// must not.
+func HoldWriteLock(dbPath string, d time.Duration) (release func(), err error) {
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout%3d5000&_txlock=immediate")
+	if err != nil {
+		return nil, err
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("take write lock: %w", err)
+	}
+	done := make(chan struct{})
+	timer := time.AfterFunc(d, func() { close(done) })
+	go func() {
+		<-done
+		_ = tx.Rollback()
+		_ = db.Close()
+	}()
+	return func() {
+		if timer.Stop() {
+			close(done)
+		}
+	}, nil
+}

--- a/e2e/harness/synthetic.go
+++ b/e2e/harness/synthetic.go
@@ -4,15 +4,24 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/SyncYomi/SyncYomi/internal/backup"
 	"github.com/SyncYomi/SyncYomi/internal/backup/pb"
 )
+
+// LegacyClientTimeout is what the v1 forks give the server: TachiyomiSY and Komikku use
+// a bare OkHttpClient() for the download and the event report, whose read timeout is 10 s.
+const LegacyClientTimeout = 10 * time.Second
+
+// legacyClient carries that timeout so the v1 helpers fail exactly when a phone would.
+var legacyClient = &http.Client{Timeout: LegacyClientTimeout}
 
 // SyntheticClient speaks SyncYomi v2 directly, acting as an extra "device" so
 // tests can seed server state or inject precise conflict/cursor situations
@@ -117,7 +126,7 @@ func (c *SyntheticClient) PutV1(ctx context.Context, raw []byte, ifMatch string,
 	if gzipBody {
 		req.Header.Set("Content-Encoding", "gzip")
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := legacyClient.Do(req)
 	if err != nil {
 		return "", 0, err
 	}
@@ -137,7 +146,7 @@ func (c *SyntheticClient) GetV1(ctx context.Context, ifNoneMatch string) (data [
 	if ifNoneMatch != "" {
 		req.Header.Set("If-None-Match", ifNoneMatch)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := legacyClient.Do(req)
 	if err != nil {
 		return nil, "", 0, err
 	}
@@ -151,4 +160,33 @@ func (c *SyntheticClient) GetV1(ctx context.Context, ifNoneMatch string) (data [
 		return nil, "", 0, err
 	}
 	return data, resp.Header.Get("ETag"), resp.StatusCode, nil
+}
+
+// ReportEvent posts a sync event the way the forks do after each phase (SYNC_STARTED,
+// SYNC_SUCCESS, SYNC_FAILED, ...): device identity in the JSON body, not in headers.
+// Non-2xx statuses are returned, not treated as errors.
+func (c *SyntheticClient) ReportEvent(ctx context.Context, event, message string) (status int, err error) {
+	body, err := json.Marshal(map[string]string{
+		"event":       event,
+		"device_id":   c.DeviceID,
+		"device_name": c.DeviceName,
+		"message":     message,
+	})
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.Server.BaseURL+"/api/sync/event", bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Token", c.Server.APIKey)
+	resp, err := legacyClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode, nil
 }

--- a/e2e/scenarios/v1/v1_test.go
+++ b/e2e/scenarios/v1/v1_test.go
@@ -6,8 +6,11 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -253,30 +256,56 @@ func TestV1_GarbageTolerated(t *testing.T) {
 	}
 }
 
+// within runs fn with the forks' 10 s client deadline and fails the test when it takes
+// longer than budget.
+func within(t *testing.T, name string, budget time.Duration, fn func(ctx context.Context)) time.Duration {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), harness.LegacyClientTimeout)
+	defer cancel()
+	start := time.Now()
+	fn(ctx)
+	took := time.Since(start)
+	if took > budget {
+		t.Errorf("%s took %s, budget %s", name, took, budget)
+	} else {
+		t.Logf("%s: %s", name, took)
+	}
+	return took
+}
+
+// importTook reads the duration of the last v1 import from the server log, "" if none ran.
+func importTook(t *testing.T, srv *harness.SyncServer) string {
+	t.Helper()
+	log, err := os.ReadFile(srv.LogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := importTookRe.FindAllSubmatch(log, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	return string(matches[len(matches)-1][1]) + "ms"
+}
+
+// the console logger colours the field name, so an escape sequence may sit before the value
+var importTookRe = regexp.MustCompile(`imported v1 upload into the item store.*took=(?:\x1b\[[0-9;]*m)?([0-9.]+)`)
+
 func TestV1_LargeLibraryUnderTimeout(t *testing.T) {
 	srv := startServer(t, 8801)
 	v1 := harness.NewSyntheticClient(srv, "")
 	v2 := harness.NewSyntheticClient(srv, "e2e-v2-device")
 	raw := encodeFixture(t, "s6", 3600, 60)
-
-	within := func(name string, fn func(ctx context.Context)) {
-		t.Helper()
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		start := time.Now()
-		fn(ctx)
-		t.Logf("%s: %s for %d bytes", name, time.Since(start), len(raw))
-	}
+	t.Logf("payload %d bytes", len(raw))
 
 	var etag string
-	within("first put", func(ctx context.Context) {
+	within(t, "first put", harness.LegacyClientTimeout, func(ctx context.Context) {
 		tag, status, err := v1.PutV1(ctx, raw, "", false)
 		if err != nil || status != http.StatusOK {
 			t.Fatalf("put = %d, %v", status, err)
 		}
 		etag = tag
 	})
-	within("get", func(ctx context.Context) {
+	within(t, "get", harness.LegacyClientTimeout, func(ctx context.Context) {
 		data, tag, status, err := v1.GetV1(ctx, "")
 		if err != nil || status != http.StatusOK {
 			t.Fatalf("get = %d, %v", status, err)
@@ -285,7 +314,7 @@ func TestV1_LargeLibraryUnderTimeout(t *testing.T) {
 			t.Fatal("large upload not echoed")
 		}
 	})
-	within("second put", func(ctx context.Context) {
+	within(t, "second put", harness.LegacyClientTimeout, func(ctx context.Context) {
 		tag, status, err := v1.PutV1(ctx, raw, etag, false)
 		if err != nil || status != http.StatusOK {
 			t.Fatalf("second put = %d, %v", status, err)
@@ -300,13 +329,164 @@ func TestV1_LargeLibraryUnderTimeout(t *testing.T) {
 	if len(resp.BackupManga) != 3601 {
 		t.Fatalf("v2 sees %d manga, want 3601", len(resp.BackupManga))
 	}
-	within("get after v2 write", func(ctx context.Context) {
+	within(t, "get after v2 write", harness.LegacyClientTimeout, func(ctx context.Context) {
 		data, tag, status, err := v1.GetV1(ctx, etag)
 		if err != nil || status != http.StatusOK || !strings.HasPrefix(tag, "seq=") {
 			t.Fatalf("get after v2 write = %d %q, %v", status, tag, err)
 		}
 		if render, err := backup.Decode(data); err != nil || len(render.BackupManga) != 3601 {
 			t.Fatalf("render fallback = %d manga, %v", len(render.BackupManga), err)
+		}
+	})
+}
+
+// V1-S7: while something holds the database write lock for longer than a phone waits
+// (a large import does), v1 reads and event reports still answer at once; the device and
+// status bookkeeping they trigger lands once the lock is free.
+func TestV1_ResponsiveWhileStoreLocked(t *testing.T) {
+	srv := startServer(t, 8802)
+	ctx := context.Background()
+	c := harness.NewSyntheticClient(srv, "e2e-v1-phone")
+	raw := encodeFixture(t, "s7", 3600, 60)
+
+	etag, status, err := c.PutV1(ctx, raw, "", false)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("put = %d, %v", status, err)
+	}
+	if status, err := c.ReportEvent(ctx, "SYNC_STARTED", ""); err != nil || status != http.StatusNoContent {
+		t.Fatalf("event = %d, %v", status, err)
+	}
+
+	const hold = 8 * time.Second
+	release, err := harness.HoldWriteLock(filepath.Join(srv.DataDir, "syncyomi.db"), hold)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	lockedAt := time.Now()
+
+	// a phone hangs up at 10 s; two bookkeeping writes waiting for the lock used to eat it all
+	const budget = 2 * time.Second
+	within(t, "get while locked", budget, func(ctx context.Context) {
+		data, tag, status, err := c.GetV1(ctx, "")
+		if err != nil || status != http.StatusOK {
+			t.Fatalf("get = %d, %v", status, err)
+		}
+		if tag != etag || !bytes.Equal(data, raw) {
+			t.Fatal("upload not echoed")
+		}
+	})
+	within(t, "304 while locked", budget, func(ctx context.Context) {
+		if _, _, status, err := c.GetV1(ctx, etag); err != nil || status != http.StatusNotModified {
+			t.Fatalf("If-None-Match get = %d, %v", status, err)
+		}
+	})
+	within(t, "event while locked", budget, func(ctx context.Context) {
+		if status, err := c.ReportEvent(ctx, "SYNC_SUCCESS", ""); err != nil || status != http.StatusNoContent {
+			t.Fatalf("event = %d, %v", status, err)
+		}
+	})
+	if time.Since(lockedAt) >= hold {
+		t.Fatalf("the lock expired before the requests finished; raise hold")
+	}
+	release()
+
+	// writers legitimately waited; now they go through
+	within(t, "put after release", harness.LegacyClientTimeout, func(ctx context.Context) {
+		if _, status, err := c.PutV1(ctx, raw, etag, false); err != nil || status != http.StatusOK {
+			t.Fatalf("put after release = %d, %v", status, err)
+		}
+	})
+
+	// the bookkeeping the locked requests queued lands once the lock is free
+	err = harness.WaitFor(ctx, 15*time.Second, func() bool {
+		st, err := srv.Status(ctx)
+		if err != nil || st.LastProtocol != "v1" || st.LastEvent != "SYNC_SUCCESS" {
+			return false
+		}
+		devices, err := srv.Devices(ctx)
+		if err != nil {
+			return false
+		}
+		for _, d := range devices {
+			if d.DeviceID == c.DeviceID && d.LastEvent == "SYNC_SUCCESS" {
+				return true
+			}
+		}
+		return false
+	})
+	if err != nil {
+		st, _ := srv.Status(ctx)
+		devices, _ := srv.Devices(ctx)
+		t.Fatalf("bookkeeping never landed: %v (status %+v, devices %+v)", err, st, devices)
+	}
+}
+
+// V1-S8: the real thing — a v2 device's full merge imports the pending v1 upload under
+// the write lock while a v1 phone keeps polling and reporting; every one of its requests
+// answers well inside the phone's 10 s.
+func TestV1_ResponsiveDuringImport(t *testing.T) {
+	srv := startServer(t, 8803)
+	ctx := context.Background()
+	v1 := harness.NewSyntheticClient(srv, "e2e-v1-phone")
+	v2 := harness.NewSyntheticClient(srv, "e2e-v2-device")
+	raw := encodeFixture(t, "s8", 3600, 60)
+
+	etag, status, err := v1.PutV1(ctx, raw, "", false)
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("put = %d, %v", status, err)
+	}
+
+	merged := make(chan error, 1)
+	go func() {
+		resp, err := v2.Merge(ctx, harness.FixtureBackup("s8v2", 1, 1), harness.MergeOptions{Full: true})
+		if err == nil && len(resp.BackupManga) != 3601 {
+			err = fmt.Errorf("v2 sees %d manga, want 3601", len(resp.BackupManga))
+		}
+		merged <- err
+	}()
+
+	const budget = 3 * time.Second
+	var rounds int
+	var maxGet, maxEvent time.Duration
+	for done := false; !done; {
+		select {
+		case err := <-merged:
+			if err != nil {
+				t.Fatalf("v2 full merge: %v", err)
+			}
+			done = true
+		default:
+		}
+		maxGet = max(maxGet, within(t, "get during import", budget, func(ctx context.Context) {
+			data, tag, status, err := v1.GetV1(ctx, "")
+			if err != nil || status != http.StatusOK {
+				t.Fatalf("get = %d, %v", status, err)
+			}
+			// the echo until the import commits, the render afterwards
+			if tag == etag && !bytes.Equal(data, raw) {
+				t.Fatal("upload not echoed")
+			}
+		}))
+		maxEvent = max(maxEvent, within(t, "event during import", budget, func(ctx context.Context) {
+			if status, err := v1.ReportEvent(ctx, "SYNC_STARTED", ""); err != nil || status != http.StatusNoContent {
+				t.Fatalf("event = %d, %v", status, err)
+			}
+		}))
+		rounds++
+		if !done {
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+	t.Logf("%d rounds while the import ran %s: max get %s, max event %s", rounds, importTook(t, srv), maxGet, maxEvent)
+
+	within(t, "get after import", harness.LegacyClientTimeout, func(ctx context.Context) {
+		data, tag, status, err := v1.GetV1(ctx, etag)
+		if err != nil || status != http.StatusOK || !strings.HasPrefix(tag, "seq=") {
+			t.Fatalf("get after import = %d %q, %v", status, tag, err)
+		}
+		if render, err := backup.Decode(data); err != nil || len(render.BackupManga) != 3601 {
+			t.Fatalf("render = %d manga, %v", len(render.BackupManga), err)
 		}
 	})
 }

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -28,8 +28,15 @@ func (db *DB) openSQLite() error {
 
 	// Enable WAL. SQLite performs better with the WAL  because it allows
 	// multiple readers to operate while data is being written.
-	if _, err = db.handler.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+	// The pragma answers with the mode actually in effect: SQLite silently keeps the
+	// rollback journal on filesystems without shared memory (network mounts, some Docker
+	// volume drivers), and there every reader blocks behind a running import.
+	var journalMode string
+	if err = db.handler.QueryRow(`PRAGMA journal_mode = wal;`).Scan(&journalMode); err != nil {
 		return errors.Wrap(err, "enable wal")
+	}
+	if journalMode != "wal" {
+		db.log.Warn().Str("journal_mode", journalMode).Msg("SQLite refused WAL mode; readers will wait for writers, keep the database on a local filesystem")
 	}
 
 	// When tachi-desk-server does not cleanly shut down, the WAL will still be present and not committed.

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -148,11 +148,17 @@ type SyncStoreTx interface {
 	SetDeviceCursor(ctx context.Context, dc DeviceCursor) error
 }
 
+// SyncStoreReader is the read-only view of the item store; on SQLite it never waits for a
+// writer, so a merge can be prepared against it while the write lock is busy.
 type SyncStoreReader interface {
 	Seq() int64
 	Exists() bool
 	RawBlob(ctx context.Context) (*RawBlob, error)
 	RenderCache(ctx context.Context) (*RenderCache, error)
+	GetItems(ctx context.Context, kind merge.Kind, keys []string) (map[string]*merge.Item, error)
+	Categories(ctx context.Context) ([]*merge.Item, error)
+	CountOfKind(ctx context.Context, kind merge.Kind) (int, error)
+	ItemsOfKind(ctx context.Context, kind merge.Kind) ([]*merge.Item, error)
 }
 
 type SyncStore interface {

--- a/internal/http/sync_test.go
+++ b/internal/http/sync_test.go
@@ -128,6 +128,8 @@ func (m *mockSyncService) GetStatus(ctx context.Context, apiKey string) (*domain
 	return m.status, m.adminErr
 }
 
+func (m *mockSyncService) Flush() {}
+
 func newRouter(mock *mockSyncService, maxBody int64) *chi.Mux {
 	r := chi.NewRouter()
 	r.Route("/", func(r chi.Router) {

--- a/internal/sync/merge.go
+++ b/internal/sync/merge.go
@@ -425,27 +425,60 @@ func (s *service) promoteLegacy(ctx context.Context, tx domain.SyncStoreTx) erro
 	return tx.SetRawBlob(ctx, rc.Data, rc.ETag, tx.Seq(), true)
 }
 
+// importPending imports the pending v1 upload inside the caller's write transaction.
 func (s *service) importPending(ctx context.Context, tx domain.SyncStoreTx) (bool, error) {
-	raw, err := tx.RawBlob(ctx)
-	if err != nil || raw == nil || !raw.Pending {
+	p, err := s.prepareImport(ctx, tx)
+	if err != nil || p == nil {
 		return false, err
 	}
+	return s.applyImport(ctx, tx, p)
+}
 
-	start := time.Now()
-	b, err := backup.Decode(raw.Data)
-	var items []*merge.Item
+// preparedImport is a pending v1 upload merged against a snapshot of the store, ready to
+// be written. seq is the store's seq the merge was computed against.
+type preparedImport struct {
+	seq     int64
+	start   time.Time
+	backup  *pb.Backup
+	items   []*merge.Item
+	res     *merge.Result
+	garbage bool // the upload cannot be decoded; mark it current and keep serving it verbatim
+}
+
+// prepareImport does the expensive part of an import — decode, split, load the stored
+// items, merge — against a reader, so it can run outside the write lock. nil when nothing
+// is pending.
+func (s *service) prepareImport(ctx context.Context, tx domain.SyncStoreReader) (*preparedImport, error) {
+	raw, err := tx.RawBlob(ctx)
+	if err != nil || raw == nil || !raw.Pending {
+		return nil, err
+	}
+
+	p := &preparedImport{seq: tx.Seq(), start: time.Now()}
+	p.backup, err = backup.Decode(raw.Data)
 	if err == nil {
-		items, err = splitBackup(b)
+		p.items, err = splitBackup(p.backup)
 	}
 	if err != nil {
 		s.log.Error().Err(err).Msg("v1 payload cannot be decoded, serving it verbatim without importing")
+		p.garbage = true
+		return p, nil
+	}
+	p.res, err = s.mergeBackup(ctx, tx, p.items, deviceLegacy, nil)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// applyImport writes a prepared import. The caller guarantees the store has not moved
+// since prepareImport (the per-key lock, or checking tx.Seq() against p.seq).
+func (s *service) applyImport(ctx context.Context, tx domain.SyncStoreTx, p *preparedImport) (bool, error) {
+	if p.garbage {
 		return false, tx.MarkRawCurrent(ctx, tx.Seq())
 	}
-	res, err := s.mergeBackup(ctx, tx, items, deviceLegacy, nil)
-	if err != nil {
-		return false, err
-	}
-	seq, err := tx.Apply(ctx, res, deviceLegacy)
+	writeStart := time.Now()
+	seq, err := tx.Apply(ctx, p.res, deviceLegacy)
 	if err != nil {
 		return false, err
 	}
@@ -453,8 +486,9 @@ func (s *service) importPending(ctx context.Context, tx domain.SyncStoreTx) (boo
 		return false, err
 	}
 	s.log.Info().
-		Int("manga", len(b.BackupManga)).Int("categories", len(b.BackupCategories)).
-		Int("items", len(items)).Int("written", len(res.Writes)).Dur("took", time.Since(start)).
+		Int("manga", len(p.backup.BackupManga)).Int("categories", len(p.backup.BackupCategories)).
+		Int("items", len(p.items)).Int("written", len(p.res.Writes)).
+		Dur("took", time.Since(p.start)).Dur("locked", time.Since(writeStart)).
 		Msg("imported v1 upload into the item store")
 	return true, nil
 }
@@ -467,7 +501,7 @@ func splitBackup(b *pb.Backup) ([]*merge.Item, error) {
 	return items, nil
 }
 
-func (s *service) mergeBackup(ctx context.Context, tx domain.SyncStoreTx, items []*merge.Item, device string, deletedCategories []int64) (*merge.Result, error) {
+func (s *service) mergeBackup(ctx context.Context, tx domain.SyncStoreReader, items []*merge.Item, device string, deletedCategories []int64) (*merge.Result, error) {
 	view, err := loadStoreView(ctx, tx, items)
 	if err != nil {
 		return nil, err
@@ -488,7 +522,7 @@ type storeView struct {
 	categories []*merge.Item
 }
 
-func loadStoreView(ctx context.Context, tx domain.SyncStoreTx, items []*merge.Item) (*storeView, error) {
+func loadStoreView(ctx context.Context, tx domain.SyncStoreReader, items []*merge.Item) (*storeView, error) {
 	keys := map[merge.Kind][]string{}
 	for _, it := range items {
 		if it.Kind != merge.KindCategory {
@@ -517,7 +551,7 @@ func loadStoreView(ctx context.Context, tx domain.SyncStoreTx, items []*merge.It
 
 const fullScanMinKeys = 500
 
-func lookupItems(ctx context.Context, tx domain.SyncStoreTx, kind merge.Kind, keys []string) (map[string]*merge.Item, error) {
+func lookupItems(ctx context.Context, tx domain.SyncStoreReader, kind merge.Kind, keys []string) (map[string]*merge.Item, error) {
 	if len(keys) > fullScanMinKeys {
 		n, err := tx.CountOfKind(ctx, kind)
 		if err != nil {

--- a/internal/sync/merge_test.go
+++ b/internal/sync/merge_test.go
@@ -473,6 +473,7 @@ func TestV1_EventTagsDeviceProtocol(t *testing.T) {
 	if err := svc.ReportSyncEvent(ctx, "key1", "SYNC_SUCCESS", domain.DeviceInfo{Name: "My Phone"}, ""); err != nil {
 		t.Fatal(err)
 	}
+	svc.Flush()
 
 	devices, err := svc.ListDevices(ctx, "key1")
 	if err != nil {

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -113,6 +113,9 @@ func (s *service) runImport(apiKey string) {
 	}
 }
 
+// ImportPending imports the pending v1 upload into the item store. The merge is prepared
+// against a read snapshot, so the write lock is only held while the result is written:
+// the per-key lock keeps the store still in between, and the seq is re-checked anyway.
 func (s *service) ImportPending(ctx context.Context, apiKey string) (bool, error) {
 	unlock, err := s.locks.lock(ctx, apiKey)
 	if err != nil {
@@ -120,10 +123,24 @@ func (s *service) ImportPending(ctx context.Context, apiKey string) (bool, error
 	}
 	defer unlock()
 
+	var prepared *preparedImport
+	err = s.store.ReadTx(ctx, apiKey, func(tx domain.SyncStoreReader) error {
+		var err error
+		prepared, err = s.prepareImport(ctx, tx)
+		return err
+	})
+	if err != nil || prepared == nil {
+		return false, err
+	}
+
 	var imported bool
 	err = s.store.Tx(ctx, apiKey, func(tx domain.SyncStoreTx) error {
 		var err error
-		imported, err = s.importPending(ctx, tx)
+		if tx.Seq() != prepared.seq {
+			imported, err = s.importPending(ctx, tx)
+			return err
+		}
+		imported, err = s.applyImport(ctx, tx, prepared)
 		return err
 	})
 	return imported, err

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -38,11 +38,18 @@ type Service interface {
 	// DeleteDevice removes a device row. domain.ErrNotFound if id is unknown for the key.
 	DeleteDevice(ctx context.Context, apiKey string, id int) error
 	GetStatus(ctx context.Context, apiKey string) (*domain.SyncStatus, error)
+	// Flush waits for the bookkeeping writes that RecordContentAccess and ReportSyncEvent
+	// run in the background.
+	Flush()
 }
 
 const (
 	importDelay   = 20 * time.Second
 	importTimeout = 10 * time.Minute
+	// bookkeepingTimeout bounds a background device/status write; it matches the SQLite
+	// busy timeout so a write never waits longer than one lock acquisition would.
+	bookkeepingTimeout = 5 * time.Second
+	bookkeepingQueue   = 1024
 )
 
 func NewService(log logger.Logger, repo domain.SyncRepo, store domain.SyncStore, notificationSvc notification.Service, apiRepo domain.APIRepo) Service {
@@ -53,8 +60,10 @@ func NewService(log logger.Logger, repo domain.SyncRepo, store domain.SyncStore,
 		notificationService: notificationSvc,
 		apiRepo:             apiRepo,
 		locks:               &keyLocks{},
+		bookkeeping:         make(chan func(), bookkeepingQueue),
 	}
 	s.scheduleImport = newImporter(importDelay, s.runImport).schedule
+	go s.runBookkeeping()
 	return s
 }
 
@@ -66,6 +75,8 @@ type service struct {
 	apiRepo             domain.APIRepo
 	locks               *keyLocks
 	scheduleImport      func(apiKey string)
+	bookkeeping         chan func()
+	bg                  gosync.WaitGroup
 }
 
 type importer struct {
@@ -138,23 +149,56 @@ func (s *service) GetStatus(ctx context.Context, apiKey string) (*domain.SyncSta
 	return s.repo.GetStatus(ctx, apiKey)
 }
 
-func (s *service) RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool, protocol string) {
-	if err := s.repo.TouchDevice(ctx, apiKey, dev, "", "", "", protocol); err != nil {
-		s.log.Warn().Err(err).Msg("failed to record device")
+// bookkeep queues a device/status write to run off the request path, in order. Those rows
+// queue behind the SQLite write lock, which a large import can hold for many seconds, and
+// v1 clients hang up after 10 s: the response must not wait for them. One worker keeps the
+// writes ordered (an event reported right after a PUT sees the PUT's status row) and stops
+// them piling up while the lock is held. The request context is detached so a client that
+// already gave up does not cancel the write.
+func (s *service) bookkeep(ctx context.Context, fn func(ctx context.Context)) {
+	s.bg.Add(1)
+	ctx = context.WithoutCancel(ctx)
+	task := func() {
+		defer s.bg.Done()
+		ctx, cancel := context.WithTimeout(ctx, bookkeepingTimeout)
+		defer cancel()
+		fn(ctx)
 	}
+	select {
+	case s.bookkeeping <- task:
+	default:
+		s.bg.Done()
+		s.log.Warn().Msg("bookkeeping queue full, dropping device/status update")
+	}
+}
 
-	// reads record the protocol too: a v1-only fleet must be flagged even if it never PUTs
-	if !write {
-		if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{LastProtocol: protocol}); err != nil {
+func (s *service) runBookkeeping() {
+	for task := range s.bookkeeping {
+		task()
+	}
+}
+
+func (s *service) Flush() {
+	s.bg.Wait()
+}
+
+func (s *service) RecordContentAccess(ctx context.Context, apiKey string, dev domain.DeviceInfo, write bool, protocol string) {
+	now := time.Now().UTC()
+	s.bookkeep(ctx, func(ctx context.Context) {
+		if err := s.repo.TouchDevice(ctx, apiKey, dev, "", "", "", protocol); err != nil {
+			s.log.Warn().Err(err).Msg("failed to record device")
+		}
+
+		// reads record the protocol too: a v1-only fleet must be flagged even if it never PUTs
+		st := domain.SyncStatus{LastProtocol: protocol}
+		if write {
+			st.LastSyncedAt = &now
+			st.LastDevice = dev.Name
+		}
+		if err := s.repo.UpsertStatus(ctx, apiKey, st); err != nil {
 			s.log.Warn().Err(err).Msg("failed to record sync status")
 		}
-		return
-	}
-
-	now := time.Now().UTC()
-	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{LastSyncedAt: &now, LastDevice: dev.Name, LastProtocol: protocol}); err != nil {
-		s.log.Warn().Err(err).Msg("failed to record sync status")
-	}
+	})
 }
 
 func (s *service) ReportSyncEvent(ctx context.Context, apiKey string, event string, dev domain.DeviceInfo, detailMessage string) error {
@@ -169,22 +213,24 @@ func (s *service) ReportSyncEvent(ctx context.Context, apiKey string, event stri
 	// rows for the same phone cannot be joined directly. When the key's last sync was v1,
 	// tag the event's device row (only if it has no protocol yet) so the UI can show one
 	// device instead of a named row plus the "legacy" aggregate.
-	protocolHint := ""
-	if st, err := s.repo.GetStatus(ctx, apiKey); err == nil && st != nil && st.LastProtocol == ProtocolV1 {
-		protocolHint = ProtocolV1
-	}
-	if err := s.repo.TouchDevice(ctx, apiKey, dev, event, status, detailMessage, protocolHint); err != nil {
-		s.log.Warn().Err(err).Msg("failed to record device")
-	}
-	if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{
-		LastEventAt: &now,
-		LastEvent:   event,
-		LastStatus:  status,
-		LastDevice:  dev.Name,
-		LastMessage: detailMessage,
-	}); err != nil {
-		s.log.Warn().Err(err).Msg("failed to record sync status")
-	}
+	s.bookkeep(ctx, func(ctx context.Context) {
+		protocolHint := ""
+		if st, err := s.repo.GetStatus(ctx, apiKey); err == nil && st != nil && st.LastProtocol == ProtocolV1 {
+			protocolHint = ProtocolV1
+		}
+		if err := s.repo.TouchDevice(ctx, apiKey, dev, event, status, detailMessage, protocolHint); err != nil {
+			s.log.Warn().Err(err).Msg("failed to record device")
+		}
+		if err := s.repo.UpsertStatus(ctx, apiKey, domain.SyncStatus{
+			LastEventAt: &now,
+			LastEvent:   event,
+			LastStatus:  status,
+			LastDevice:  dev.Name,
+			LastMessage: detailMessage,
+		}); err != nil {
+			s.log.Warn().Err(err).Msg("failed to record sync status")
+		}
+	})
 
 	keyName := "Unknown"
 	if key, err := s.apiRepo.Get(ctx, apiKey); err == nil && key != nil && key.Name != "" {

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ func main() {
 		case syscall.SIGHUP:
 			log.Log().Msg("shutting down server sighup")
 			srv.Shutdown()
+			syncService.Flush()
 			err := db.Close()
 			if err != nil {
 				log.Fatal().Stack().Err(err).Msg("could not close db connection")
@@ -135,6 +136,7 @@ func main() {
 			os.Exit(1)
 		case syscall.SIGINT, syscall.SIGQUIT:
 			srv.Shutdown()
+			syncService.Flush()
 			err := db.Close()
 			if err != nil {
 				log.Fatal().Stack().Err(err).Msg("could not close db connection")
@@ -143,6 +145,7 @@ func main() {
 			os.Exit(1)
 		case syscall.SIGKILL, syscall.SIGTERM:
 			srv.Shutdown()
+			syncService.Flush()
 			err := db.Close()
 			if err != nil {
 				log.Fatal().Stack().Err(err).Msg("could not close db connection")


### PR DESCRIPTION
Stops v1 phones timing out while the server imports a large library. Every v1 `GET`/`PUT` and every `POST /api/sync/event` upserted the device and status rows before answering; those writes queue behind the SQLite write lock, which a large import holds for seconds, and each waited up to the 5 s busy timeout. TachiyomiSY and Komikku hang up after 10 s, which is exactly two such waits, so the phone saw a timeout on requests whose real work took milliseconds and the server logged `context canceled` in `RawBlob`, `TouchDevice` and `UpsertStatus`. The v1 wire behaviour (byte-for-byte echo, `uuid=` etags, `If-Match`) is unchanged.

- Device and status bookkeeping runs on a single ordered background worker with a detached context and a 5 s cap; a response never waits for the write lock, and an event reported right after a `PUT` still sees the `PUT`'s status row.
- The background import decodes, loads and merges against a read snapshot and takes the write lock only to apply the result: ~40 ms held instead of ~750 ms for a re-upload of an unchanged 3600 x 60 library on a desktop. The `imported v1 upload` log line now reports the hold as `locked`.
- SQLite logs a warning when the filesystem refuses WAL mode, where readers block behind writers too.
- The v1 e2e clients now carry the forks' 10 s timeout and can report events; a new scenario holds the write lock from the test for 8 s and requires `GET`, `304` and event to answer within 2 s (5 s and 3 s before the fix), another polls while a v2 full merge imports the pending upload.
- `Flush` on the sync service drains the queue at shutdown and in tests.

Follows #226 (#225).
