### PR TITLE
test(e2e): keep Maestro debug output in failure artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -285,6 +285,8 @@ jobs:
           name: e2e-failure-artifacts-${{ matrix.name }}
           path: e2e/artifacts/
           retention-days: 7
+          # Maestro's detailed log and screenshots live under .maestro/
+          include-hidden-files: true
 
   # the required check: passes when the shards passed or were skipped on purpose,
   # fails when the changes job or any shard failed

--- a/e2e/harness/maestro.go
+++ b/e2e/harness/maestro.go
@@ -44,6 +44,7 @@ func (e *Emulator) RunFlow(ctx context.Context, flowPath, artifactDir string, fl
 		// retry is safe; a mid-flow failure is not retried (steps may not be
 		// idempotent) and fails loudly instead.
 		if attempt == 1 && !bytesContains(out, "COMPLETED") {
+			_ = os.Rename(logPath, filepath.Join(outDir, "maestro-attempt1.log"))
 			continue
 		}
 		return fmt.Errorf("maestro flow %s on %s failed (log: %s): %w", filepath.Base(flowPath), e.AVD, logPath, err)


### PR DESCRIPTION
Keeps enough of Maestro's output to diagnose a flow that dies before its first step. The `e2e-failure-artifacts-*` upload now includes the hidden `.maestro/` directory that Maestro writes under `--debug-output` (its detailed log and screenshots), and when the harness retries a flow that crashed before any step completed, the first attempt's console log is kept as `maestro-attempt1.log` instead of being overwritten. Flow behaviour and the retry rule are unchanged.

On #239 the `categories` shard once failed S10 and S12 at `launchApp` on device a and passed on the next run; the artifacts carried only the second attempt's console output with no reason, and the logcat `main` buffer covered about ten seconds, so the next occurrence would have been just as opaque.

Follows #239.
